### PR TITLE
fix: nullable address fields in marketing preference model

### DIFF
--- a/src/Model/SQS/MarketingPreference.model.js
+++ b/src/Model/SQS/MarketingPreference.model.js
@@ -155,7 +155,7 @@ export default class MarketingPreference extends Model {
    * @param value string
    */
   setAddress2(value: string) {
-    this.address2 = value;
+    this.address2 = typeof value === 'undefined' || value.trim() === '' ? null : value;
   }
 
   /**
@@ -171,7 +171,7 @@ export default class MarketingPreference extends Model {
    * @param value string
    */
   setAddress3(value: string) {
-    this.address3 = value;
+    this.address3 = typeof value === 'undefined' || value.trim() === '' ? null : value;
   }
 
   /**

--- a/tests/unit/Model/SQS/MarketingPreferences.model.js
+++ b/tests/unit/Model/SQS/MarketingPreferences.model.js
@@ -58,7 +58,7 @@ describe('Model/MarketingPreferencesModel', () => {
     });
 
     it('should set and get the address3', () => {
-      expect(model.getAddress3()).to.eql(mockedData.address3);
+      expect(model.getAddress3()).to.eql(null);
     });
 
     it('should set and get the town', () => {


### PR DESCRIPTION
fix: #38 - nullable address fields in marketing preference model
