### PR TITLE
Fix timeouts thrown even when a response is already returned

### DIFF
--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -6,7 +6,7 @@ import DependencyInjection from '../DependencyInjection/DependencyInjection.clas
 import { DEFINITIONS } from '../Config/Dependencies';
 
 export default ((configuration, handler) => {
-  let instance = (event, context) => {
+  let instance = (event, context, callback) => {
     const di = new DependencyInjection(configuration, event, context);
     const request = di.get(DEFINITIONS.REQUEST);
     const logger = di.get(DEFINITIONS.LOGGER);
@@ -15,7 +15,7 @@ export default ((configuration, handler) => {
 
     // If the event is to trigger a warm up, then don't bother returning the function.
     if (di.getEvent().source === 'serverless-plugin-warmup') {
-      return context.done(null, 'Lambda is warm!');
+      return callback(null, 'Lambda is warm!');
     }
 
     // Log the users ip address silently for use in error tracing
@@ -31,7 +31,7 @@ export default ((configuration, handler) => {
       });
     }
 
-    return handler.call(instance, di, request, context.done);
+    return handler.call(instance, di, request, callback);
   };
 
   // If the IOPipe token is enabled, then wrap the instance in the IOPipe wrapper


### PR DESCRIPTION
This happens locally during development.