### PR TITLE
fix: Removed babel deps added in 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "@babel/node": "^7.0.0",
     "@babel/plugin-syntax-flow": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-    "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.0.0",
-    "@babel/runtime": "^7.11.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-istanbul": "^6.0.0",
     "eslint": "^7.5.0",
@@ -58,8 +56,7 @@
     ],
     "plugins": [
       "@babel/plugin-syntax-flow",
-      "@babel/plugin-transform-flow-strip-types",
-      ["@babel/plugin-transform-runtime", { "regenerator": true }]
+      "@babel/plugin-transform-flow-strip-types"
     ]
   },
   "nyc": {

--- a/tests/unit/Wrapper/LambdaWrapper.js
+++ b/tests/unit/Wrapper/LambdaWrapper.js
@@ -102,18 +102,22 @@ describe('Wrapper/LambdaWrapper', () => {
       expect(body.message).to.be.equal('some message');
     });
 
-    it('Catches async errors', async () => {
-      const lambda = LambdaWrapper(configuration, async di => {
-        sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-        throw new LambdaTermination('internal', 403, 'external');
+    it('Catches async errors', () => {
+      const lambda = LambdaWrapper(configuration, di => {
+        return new Promise((resolve) => {
+          sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
+          throw new LambdaTermination('internal', 403, 'external');
+        });
       });
 
-      const response = await lambda(getEvent, getContext);
-      const body = JSON.parse(response.body);
+      return lambda(getEvent, getContext)
+        .then((response) => {
+          const body = JSON.parse(response.body);
 
-      expect(response.statusCode).to.be.equal(403);
-      expect(body.message).to.be.equal('unknown error');
-      expect(body.data).to.be.equal('external');
+          expect(response.statusCode).to.be.equal(403);
+          expect(body.message).to.be.equal('unknown error');
+          expect(body.data).to.be.equal('external');
+        });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,16 +666,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-runtime@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz#e27f78eb36f19448636e05c33c90fd9ad9b8bccf"
-  integrity sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==
-  dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    resolve "^1.8.1"
-    semver "^5.5.1"
-
 "@babel/plugin-transform-shorthand-properties@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz#9fd25ec5cdd555bb7f473e5e6ee1c971eede4dd6"
@@ -819,13 +809,6 @@
     make-dir "^2.1.0"
     pirates "^4.0.0"
     source-map-support "^0.5.16"
-
-"@babel/runtime@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
-  integrity sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.8.4":
   version "7.10.5"
@@ -8178,7 +8161,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
They are not really required if we removed `async` from unit tests and they were forcing implementing apps to add @babel/runtime to the dependencies.