### PR TITLE
fix: Add more descriptive names to SQS timers (#76)

### DIFF
--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -62,7 +62,7 @@ export default class SQSService extends DependencyAwareClass {
     const queueUrl = this.queues[queue];
     const Logger = this.getContainer().get(DEFINITIONS.LOGGER);
     const Timer = this.getContainer().get(DEFINITIONS.TIMER);
-    const timerId = `sqs-batch-delete-${UUID()}`;
+    const timerId = `sqs-batch-delete-${UUID()} - Queue: '${queueUrl}'`;
 
     return new Promise((resolve) => {
       const messagesForDeletion = [];
@@ -139,7 +139,7 @@ export default class SQSService extends DependencyAwareClass {
     const queueUrl = this.queues[queue];
     const Logger = this.getContainer().get(DEFINITIONS.LOGGER);
     const Timer = this.getContainer().get(DEFINITIONS.TIMER);
-    const timerId = `sqs-get-queue-attributes-${UUID()}`;
+    const timerId = `sqs-get-queue-attributes-${UUID()} - Queue: '${queueUrl}'`;
 
     return new Promise((resolve) => {
       Timer.start(timerId);
@@ -171,7 +171,7 @@ export default class SQSService extends DependencyAwareClass {
     const queueUrl = this.queues[queue];
     const Logger = this.getContainer().get(DEFINITIONS.LOGGER);
     const Timer = this.getContainer().get(DEFINITIONS.TIMER);
-    const timerId = `sqs-send-message-${UUID()}`;
+    const timerId = `sqs-send-message-${UUID()} - Queue: '${queueUrl}'`;
 
     return new Promise((resolve) => {
       Timer.start(timerId);
@@ -210,7 +210,7 @@ export default class SQSService extends DependencyAwareClass {
     const queueUrl = this.queues[queue];
     const Logger = this.getContainer().get(DEFINITIONS.LOGGER);
     const Timer = this.getContainer().get(DEFINITIONS.TIMER);
-    const timerId = `sqs-receive-message-${UUID()}`;
+    const timerId = `sqs-receive-message-${UUID()} - Queue: '${queueUrl}'`;
 
     return new Promise((resolve, reject) => {
       Timer.start(timerId);


### PR DESCRIPTION
The full qualified queue URL is not included in the timer id for each timer where the queue URL is available.

Closes #76 