### PR TITLE
fix: Add ResponseModel.generate shortcut

### DIFF
--- a/src/Model/Response.model.js
+++ b/src/Model/Response.model.js
@@ -96,4 +96,23 @@ export default class ResponseModel extends Model {
       body: JSON.stringify(this.body),
     };
   }
+
+  /**
+   * Shorthand static method
+   * that generates the response immediately
+   * if no additional processing is required.
+   *
+   * Saves only 1 line of code
+   * but keeps code terse in a lot of places.
+   *
+   * @param {*} data
+   * @param {*} code
+   * @param {*} message
+   * @returns {object}
+   */
+  static generate(data = null, code = null, message = null) {
+    const response = new this(data, code, message);
+
+    return response.generate();
+  }
 }

--- a/tests/unit/Model/Response.model.test.js
+++ b/tests/unit/Model/Response.model.test.js
@@ -73,4 +73,17 @@ describe('Model/ResponseModel', () => {
       expect(JSON.parse(response.generate().body).message).toEqual('test');
     });
   });
+
+  describe('generate', () => {
+    it('static and instance method produce the same output', () => {
+      const data = { a: 1, b: { c: 2 } };
+      const code = 201;
+      const message = 'Some message';
+
+      const response1 = new ResponseModel(data, code, message).generate();
+      const response2 = ResponseModel.generate(data, code, message);
+
+      expect(response1).toEqual(response2);
+    });
+  });
 });


### PR DESCRIPTION
Currently we generate response objects by using:
>>> const response = new ResponseModel(body, code, message);
>>> // some processing
>>> return response.generate()

However a lot of times no processing is actually performed and we create a ResponseModel object just to use its `generate` method.

A static method named `generate` has been added to compress response model creation & response generation into one line:
>>> return ResponseModel.generate(body, code, message);

Apart from moving the number of lines from 2 to 1 in a lot of places the static method is more terse and easier to understand. More over we can to without an intermediate "response" object, freeing the name for API responses performed in the Lambda.