### PR TITLE
fix: 4xx error should log INFO and not ERROR

### DIFF
--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -12,7 +12,11 @@ export default (configuration, handler) => {
     const logger = di.get(DEFINITIONS.LOGGER);
 
     const handleError = (error) => {
-      logger.error(error);
+      if (error.code && error.code >= 400 && error.code < 500) {
+        logger.info(error);
+      } else {
+        logger.error(error);
+      }
 
       const responseDetails = {
         body: error.body || {},


### PR DESCRIPTION
No point in logging an error for a planned failure (4xx).

Closes #103