### PR TITLE
feat: Add getters for headers

### DIFF
--- a/src/Service/Request.service.js
+++ b/src/Service/Request.service.js
@@ -42,6 +42,36 @@ export default class RequestService extends DependencyAwareClass {
   }
 
   /**
+   * Get all HTTP headers included in the request.
+   *
+   * @returns {object} An object with a key for each header.
+   */
+  getAllHeaders() {
+    return { ...this.getContainer().getEvent().headers };
+  }
+
+  /**
+   * Get an HTTP header from the request.
+   *
+   * The header name is case-insensitive.
+   *
+   * @param {string} name The name of the header.
+   * @param {string} [whenMissing] Value to return if the header is missing.
+   *   (default: empty string)
+   *
+   * @returns {string}
+   */
+  getHeader(name: string, whenMissing: string = '') {
+    const headers = this.getAllHeaders();
+    if (!headers) {
+      return whenMissing;
+    }
+    const lowerName = name.toLowerCase();
+    const key = Object.keys(headers).find((k) => k.toLowerCase() === lowerName);
+    return (key && headers[key]) || whenMissing;
+  }
+
+  /**
    * Get authorization token
    * @return {*}
    */

--- a/tests/unit/Service/Request.service.test.js
+++ b/tests/unit/Service/Request.service.test.js
@@ -210,4 +210,36 @@ describe('Service/RequestService', () => {
       });
     });
   });
+
+  describe('getAllHeaders()', () => {
+    const event = { ...getEvent };
+    const di = new DependencyInjection(CONFIGURATION, event, getContext);
+    const request = new RequestService(di);
+
+    it('should return all headers from the event', () => {
+      expect(request.getAllHeaders()).toStrictEqual(getEvent.headers);
+    });
+  });
+
+  describe('getHeader()', () => {
+    const event = { ...getEvent };
+    const di = new DependencyInjection(CONFIGURATION, event, getContext);
+    const request = new RequestService(di);
+
+    it('should return the specified header', () => {
+      expect(request.getHeader('Accept')).toEqual(event.headers.Accept);
+    });
+
+    it("should return '' by default if header is missing", () => {
+      expect(request.getHeader('Authorization')).toEqual('');
+    });
+
+    it("should return `whenMissing` if header is missing", () => {
+      expect(request.getHeader('Authorization', 'none')).toEqual('none');
+    });
+
+    it('should not be case-sensitive', () => {
+      expect(request.getHeader('accept')).toEqual(event.headers.Accept);
+    });
+  });
 });


### PR DESCRIPTION
Adds two new methods to `RequestService`:

- `getAllHeaders()`: shortcut for `request.getContainer().getEvent().headers`
- `getHeader(name, default='')`: get a header value using a case-insensitive search

Some of the existing code can then be significantly improved using `getHeader`.