### PR TITLE
fix: Implement getter for `CONFIGURATION.DEFINITIONS`

### DIFF
--- a/src/DependencyInjection/DependencyAware.class.js
+++ b/src/DependencyInjection/DependencyAware.class.js
@@ -19,4 +19,13 @@ export default class DependencyAwareClass {
   getContainer() {
     return this.di;
   }
+
+  /**
+   * Shortcut for `this.getContainer().definitions`
+   *
+   * @returns {object}
+   */
+  get definitions() {
+    return this.getContainer().definitions;
+  }
 }

--- a/src/DependencyInjection/DependencyInjection.class.js
+++ b/src/DependencyInjection/DependencyInjection.class.js
@@ -100,4 +100,16 @@ export default class DependencyInjection {
 
     return false;
   }
+
+  /**
+   * Returns the definitions
+   * associated to this DependencyInjection
+   * so that services can refer to them
+   * without causing circular imports.
+   *
+   * @returns {object}
+   */
+  get definitions() {
+    return this.configuration.DEFINITIONS;
+  }
 }

--- a/tests/unit/DependencyInjection/DependencyAware.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyAware.class.test.js
@@ -19,11 +19,11 @@ describe('DependencyInjection/DependencyAwareClass', () => {
       [
         [{}, undefined],
         [{ DEFINITIONS: 1 }, 1],
-      ].forEach((testCase) => {
-        it(`With configuration: ${testCase[0]}`, () => {
-          const di = new DependencyInjection(testCase[0]);
+      ].forEach(([configuration, expected]) => {
+        it(`With configuration: ${configuration}`, () => {
+          const di = new DependencyInjection(configuration);
           const service = new DependencyAware(di);
-          expect(service.definitions).toEqual(testCase[1]);
+          expect(service.definitions).toEqual(expected);
         });
       });
     });

--- a/tests/unit/DependencyInjection/DependencyAware.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyAware.class.test.js
@@ -5,10 +5,27 @@ const getEvent = require('../../mocks/aws/event.json');
 const getContext = require('../../mocks/aws/context.json');
 
 describe('DependencyInjection/DependencyAwareClass', () => {
-  const dependencyInjectionClass = new DependencyInjection({}, getEvent, getContext);
-  const dependencyAwareClass = new DependencyAware(dependencyInjectionClass);
+  describe('getContainer', () => {
+    const dependencyInjectionClass = new DependencyInjection({}, getEvent, getContext);
+    const dependencyAwareClass = new DependencyAware(dependencyInjectionClass);
 
-  it('should instantiate and be able to get the dependency injection container', () => {
-    expect(dependencyAwareClass.getContainer()).toEqual(dependencyInjectionClass);
+    it('should instantiate and be able to get the dependency injection container', () => {
+      expect(dependencyAwareClass.getContainer()).toEqual(dependencyInjectionClass);
+    });
+  });
+
+  describe('definitions', () => {
+    describe('Returns the provided definitions', () => {
+      [
+        [{}, undefined],
+        [{ DEFINITIONS: 1 }, 1],
+      ].forEach((testCase) => {
+        it(`With configuration: ${testCase[0]}`, () => {
+          const di = new DependencyInjection(testCase[0]);
+          const service = new DependencyAware(di);
+          expect(service.definitions).toEqual(testCase[1]);
+        });
+      });
+    });
   });
 });

--- a/tests/unit/DependencyInjection/DependencyInjection.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyInjection.class.test.js
@@ -92,10 +92,10 @@ describe('DependencyInjection/DependencyInjectionClass', () => {
       [
         [{}, undefined],
         [{ DEFINITIONS: 1 }, 1],
-      ].forEach((testCase) => {
-        it(`With configuration: ${testCase[0]}`, () => {
-          const di = new DependencyInjection(testCase[0]);
-          expect(di.definitions).toEqual(testCase[1]);
+      ].forEach(([configuration, expected]) => {
+        it(`With configuration: ${configuration}`, () => {
+          const di = new DependencyInjection(configuration);
+          expect(di.definitions).toEqual(expected);
         });
       });
     });

--- a/tests/unit/DependencyInjection/DependencyInjection.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyInjection.class.test.js
@@ -86,4 +86,18 @@ describe('DependencyInjection/DependencyInjectionClass', () => {
       });
     });
   });
+
+  describe('definitions', () => {
+    describe('Returns the provided definitions', () => {
+      [
+        [{}, undefined],
+        [{ DEFINITIONS: 1 }, 1],
+      ].forEach((testCase) => {
+        it(`With configuration: ${testCase[0]}`, () => {
+          const di = new DependencyInjection(testCase[0]);
+          expect(di.definitions).toEqual(testCase[1]);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Currently we need to import the `DEFINITIONS` from `src/config/Configuration` and this can lead to circular imports. There isn't really a need for that as we `di` contains `configuration`, which in turns contains `DEFINITIONS`.

A getter will simplify how we access to those constants.

See:
- [ENG-48]

[ENG-48]: https://comicrelief.atlassian.net/browse/ENG-48