### PR TITLE
fix: Allow HTTP4xx to be logged on Epsagon

### DIFF
--- a/tests/lib/mocks.js
+++ b/tests/lib/mocks.js
@@ -1,0 +1,48 @@
+import { DEFINITIONS } from '../../src/Config/Dependencies';
+
+/**
+ * Returns a mocked logger.
+ *
+ * You can pass an overrides object
+ * specifying the return values
+ * and/or behaviour for each property.
+ *
+ * @param {object} overrides
+ * @param {object} di
+ */
+export const getMockedLogger = (overrides = {}, di = null) => {
+  const logger = {
+    di,
+    error: jest.fn().mockImplementation(() => overrides.error || null),
+    info: jest.fn().mockImplementation(() => overrides.info || null),
+  };
+
+  logger.getContainer = () => logger.di;
+
+  return logger;
+};
+
+/**
+ * Returns a mocked di.
+ *
+ * You can pass an overrides object
+ * specifying the behaviour of a depedendency.
+ *
+ * @param {object} overrides
+ */
+export const getMockedDi = (overrides = {}) => {
+  const deps = {
+    [DEFINITIONS.LOGGER]: null,
+    ...overrides,
+  };
+  const di = {
+    deps,
+    get: (key) => deps[key],
+  };
+
+  if (!deps[DEFINITIONS.LOGGER]) {
+    deps[DEFINITIONS.LOGGER] = getMockedLogger({}, di);
+  }
+
+  return di;
+};

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -3,8 +3,9 @@ import sinon from 'sinon';
 import { DEFINITIONS } from '../../../src/Config/Dependencies';
 import RequestService, { REQUEST_TYPES } from '../../../src/Service/Request.service';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
-import LambdaWrapper from '../../../src/Wrapper/LambdaWrapper';
+import LambdaWrapper, { handleError } from '../../../src/Wrapper/LambdaWrapper';
 import LambdaTermination from '../../../src/Wrapper/LambdaTermination';
+import { getMockedDi } from '../../lib/mocks';
 
 const getEvent = require('../../mocks/aws/event.json');
 const getContext = require('../../mocks/aws/context.json');
@@ -26,88 +27,83 @@ describe('Wrapper/LambdaWrapper', () => {
 
   afterEach(() => sinon.restore());
 
-  describe('should inject dependency injection into the function', () => {
-    LambdaWrapper(configuration, (di, request) => {
-      dependencyInjection = di;
-      requestService = request;
-    })(getEvent, getContext);
+  describe('handleError', () => {
+    [
+      [undefined, 400, 0],
+      [false, 400, 0],
+      [true, 400, 1],
+      [undefined, undefined, 1],
+      [undefined, false, 1],
+      [undefined, 500, 1],
+      [true, 500, 1],
+    ].forEach(([raiseOnEpsagon, code, expected]) => {
+      it(`error.raiseOnEpsagon = '${raiseOnEpsagon}', code = '${code}' logger.error called ${expected} times`, () => {
+        const di = getMockedDi();
+        const logger = di.get(DEFINITIONS.LOGGER);
+        const error = { raiseOnEpsagon, code };
 
-    it('dependency injection variables should be an instance of the dependency injection class', () => {
-      expect(dependencyInjection instanceof DependencyInjection).toEqual(true);
-    });
+        handleError(di, error);
 
-    it('dependency injection should output the event that was provided to it', () => {
-      expect(dependencyInjection.getEvent()).toEqual(getEvent);
-    });
-
-    it('dependency injection should output the event that was provided to it', () => {
-      expect(dependencyInjection.getContext()).toEqual(getContext);
-    });
-  });
-
-  describe('should inject the request service into the function', () => {
-    LambdaWrapper(configuration, (di, request) => {
-      dependencyInjection = di;
-      requestService = request;
-    })(getEvent, getContext);
-
-    it('request service variables should be an instance of the dependency injection class', () => {
-      expect(requestService instanceof RequestService).toEqual(true);
-    });
-
-    it('request service should contain variables that were sent to it via the event', () => {
-      expect(requestService.get('test', null, REQUEST_TYPES.GET)).toEqual(getEvent.queryStringParameters.test);
-    });
-  });
-
-  describe('should catch exceptions and generate appropriate responses', () => {
-    it('Logs.error the error without error code', () => {
-      let infoStub;
-      let errorStub;
-
-      const lambda = LambdaWrapper(configuration, (di) => {
-        infoStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'info');
-        errorStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-        throw new Error('Undefined error');
+        expect(logger.error).toHaveBeenCalledTimes(expected);
       });
 
-      lambda(getEvent, getContext);
+      [undefined, { data: 1 }].forEach((body) => {
+        it('Generates a response object', () => {
+          const di = getMockedDi();
+          const error = { raiseOnEpsagon, code, body };
 
-      expect(infoStub.called).toEqual(false);
-      expect(errorStub.called).toEqual(true);
-    });
+          const response = handleError(di, error);
 
-    [400, 401, 403, 404, 409, 419, 421, 423, 499].forEach((errorCode) => {
-      it(`Logs.info the error with code ${errorCode}`, () => {
-        let infoStub;
-        let errorStub;
-
-        const lambda = LambdaWrapper(configuration, (di) => {
-          infoStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'info');
-          errorStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-          const error = new Error('4xx error');
-          error.code = errorCode;
-          throw error;
+          expect(response).toMatchSnapshot();
         });
+      });
+    });
+  });
 
-        lambda(getEvent, getContext);
+  describe('LambdaWrapper', () => {
+    describe('should inject dependency injection into the function', () => {
+      LambdaWrapper(configuration, (di, request) => {
+        dependencyInjection = di;
+        requestService = request;
+      })(getEvent, getContext);
 
-        expect(infoStub.called).toEqual(true);
-        expect(errorStub.called).toEqual(false);
+      it('dependency injection variables should be an instance of the dependency injection class', () => {
+        expect(dependencyInjection instanceof DependencyInjection).toEqual(true);
+      });
+
+      it('dependency injection should output the event that was provided to it', () => {
+        expect(dependencyInjection.getEvent()).toEqual(getEvent);
+      });
+
+      it('dependency injection should output the event that was provided to it', () => {
+        expect(dependencyInjection.getContext()).toEqual(getContext);
       });
     });
 
-    [500, 501, 502, 503].forEach((errorCode) => {
-      it(`Logs.error the error with code ${errorCode}`, () => {
+    describe('should inject the request service into the function', () => {
+      LambdaWrapper(configuration, (di, request) => {
+        dependencyInjection = di;
+        requestService = request;
+      })(getEvent, getContext);
+
+      it('request service variables should be an instance of the dependency injection class', () => {
+        expect(requestService instanceof RequestService).toEqual(true);
+      });
+
+      it('request service should contain variables that were sent to it via the event', () => {
+        expect(requestService.get('test', null, REQUEST_TYPES.GET)).toEqual(getEvent.queryStringParameters.test);
+      });
+    });
+
+    describe('should catch exceptions and generate appropriate responses', () => {
+      it('Logs.error the error without error code', () => {
         let infoStub;
         let errorStub;
 
         const lambda = LambdaWrapper(configuration, (di) => {
           infoStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'info');
           errorStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-          const error = new Error('5xx error');
-          error.code = errorCode;
-          throw error;
+          throw new Error('Undefined error');
         });
 
         lambda(getEvent, getContext);
@@ -115,49 +111,89 @@ describe('Wrapper/LambdaWrapper', () => {
         expect(infoStub.called).toEqual(false);
         expect(errorStub.called).toEqual(true);
       });
-    });
 
-    it('Returns 500 exception with a common error', () => {
-      const lambda = LambdaWrapper(configuration, (di) => {
-        sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-        throw new Error('Some error');
-      });
+      [400, 401, 403, 404, 409, 419, 421, 423, 499].forEach((errorCode) => {
+        it(`Logs.info the error with code ${errorCode}`, () => {
+          let infoStub;
+          let errorStub;
 
-      const response = lambda(getEvent, getContext);
-      const body = JSON.parse(response.body);
+          const lambda = LambdaWrapper(configuration, (di) => {
+            infoStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'info');
+            errorStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
+            const error = new Error('4xx error');
+            error.code = errorCode;
+            throw error;
+          });
 
-      expect(response.statusCode).toEqual(500);
-      expect(body.message).toEqual('unknown error');
-    });
+          lambda(getEvent, getContext);
 
-    it('Returns a response generated by LambdaTermination', () => {
-      const lambda = LambdaWrapper(configuration, (di) => {
-        sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-        throw new LambdaTermination('internal', 403, 'external', 'some message');
-      });
-
-      const response = lambda(getEvent, getContext);
-      const body = JSON.parse(response.body);
-
-      expect(response.statusCode).toEqual(403);
-      expect(body.data).toEqual('external');
-      expect(body.message).toEqual('some message');
-    });
-
-    it('Catches async errors', () => {
-      const lambda = LambdaWrapper(configuration, (di) => {
-        return new Promise(() => {
-          sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
-          throw new LambdaTermination('internal', 403, 'external');
+          expect(infoStub.called).toEqual(true);
+          expect(errorStub.called).toEqual(false);
         });
       });
 
-      return lambda(getEvent, getContext).then((response) => {
+      [500, 501, 502, 503].forEach((errorCode) => {
+        it(`Logs.error the error with code ${errorCode}`, () => {
+          let infoStub;
+          let errorStub;
+
+          const lambda = LambdaWrapper(configuration, (di) => {
+            infoStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'info');
+            errorStub = sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
+            const error = new Error('5xx error');
+            error.code = errorCode;
+            throw error;
+          });
+
+          lambda(getEvent, getContext);
+
+          expect(infoStub.called).toEqual(false);
+          expect(errorStub.called).toEqual(true);
+        });
+      });
+
+      it('Returns 500 exception with a common error', () => {
+        const lambda = LambdaWrapper(configuration, (di) => {
+          sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
+          throw new Error('Some error');
+        });
+
+        const response = lambda(getEvent, getContext);
+        const body = JSON.parse(response.body);
+
+        expect(response.statusCode).toEqual(500);
+        expect(body.message).toEqual('unknown error');
+      });
+
+      it('Returns a response generated by LambdaTermination', () => {
+        const lambda = LambdaWrapper(configuration, (di) => {
+          sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
+          throw new LambdaTermination('internal', 403, 'external', 'some message');
+        });
+
+        const response = lambda(getEvent, getContext);
         const body = JSON.parse(response.body);
 
         expect(response.statusCode).toEqual(403);
-        expect(body.message).toEqual('unknown error');
         expect(body.data).toEqual('external');
+        expect(body.message).toEqual('some message');
+      });
+
+      it('Catches async errors', () => {
+        const lambda = LambdaWrapper(configuration, (di) => {
+          return new Promise(() => {
+            sinon.stub(di.dependencies[DEFINITIONS.LOGGER], 'error');
+            throw new LambdaTermination('internal', 403, 'external');
+          });
+        });
+
+        return lambda(getEvent, getContext).then((response) => {
+          const body = JSON.parse(response.body);
+
+          expect(response.statusCode).toEqual(403);
+          expect(body.message).toEqual('unknown error');
+          expect(body.data).toEqual('external');
+        });
       });
     });
   });

--- a/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
+++ b/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 1`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 400,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 2`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 400,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 3`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 400,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 4`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 400,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 5`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 400,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 6`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 400,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 7`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 8`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 9`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 10`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 11`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 12`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 13`] = `
+Object {
+  "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Generates a response object 14`] = `
+Object {
+  "body": "{\\"data\\":{\\"data\\":1},\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 500,
+}
+`;


### PR DESCRIPTION
Our error handling on Lambda Wrapper checks whether `error.code` is defined and below 500 (meaning a 4xx error). While this makes sense in most uses cases, as we are unlikely to be interested at all in 4xx errors, there are scenarios where we are forced to throw a 4xx and we might be interested in logging in.

This is correlated to [ENG-110].

Error handling will check whether `error.raiseOnEpsagon` is defined and true. This condition will override the error code check, allowing us to put some dynamic logic on whether an error should be logged on Epsagon regardless of code. For example, we might not care about the first time we get an HTTP 417 and just retry, but be alarmed once it gets on the DLQ.

See:
- [ENG-110]
- [ENG-111]

[ENG-110]: https://comicrelief.atlassian.net/browse/ENG-110
[ENG-110]: https://comicrelief.atlassian.net/browse/ENG-110
[ENG-111]: https://comicrelief.atlassian.net/browse/ENG-111