### PR TITLE
fix: Improve error logging for axios errors

### DIFF
--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -37,9 +37,9 @@ export const handleError = (di, error) => {
         },
       };
     } catch {
-    // if the axios error is incomplete
-    // for any reason, we don't want
-    // error handling to fail
+      // if the axios error is incomplete
+      // for any reason, we don't want
+      // error handling to fail
       errorBody = error;
     }
   }

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -34,11 +34,19 @@ export const handleError = (di, error) => {
       // only keep error.config, error.response.status, error.response.data
       errorBody = {
         config: error.config,
-        response: {
+        message: error.message,
+      };
+
+      // It's pretty common for axios errors
+      // to not have.response e.g.when there's
+      // a network error or timeout.
+      // These errors will have .request but not .response.
+      if (error.response) {
+        errorBody.response = {
           status: error.response.status,
           data: error.response.data,
-        },
-      };
+        };
+      }
     } catch {
       // if the axios error is incomplete
       // for any reason, we don't want

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -30,28 +30,21 @@ export const handleError = (di, error) => {
   // While handling an error, lambda wrapper should
   // recognise axios errors and trim down the information
   if (errorBody.isAxiosError) {
-    try {
-      // only keep error.config, error.response.status, error.response.data
-      errorBody = {
-        config: error.config,
-        message: error.message,
-      };
+    // only keep error.config, error.response.status, error.response.data
+    errorBody = {
+      config: error.config,
+      message: error.message,
+    };
 
-      // It's pretty common for axios errors
-      // to not have.response e.g.when there's
-      // a network error or timeout.
-      // These errors will have .request but not .response.
-      if (error.response) {
-        errorBody.response = {
-          status: error.response.status,
-          data: error.response.data,
-        };
-      }
-    } catch {
-      // if the axios error is incomplete
-      // for any reason, we don't want
-      // error handling to fail
-      errorBody = error;
+    // It's pretty common for axios errors
+    // to not have.response e.g.when there's
+    // a network error or timeout.
+    // These errors will have .request but not .response.
+    if (error.response) {
+      errorBody.response = {
+        status: error.response.status,
+        data: error.response.data,
+      };
     }
   }
 

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -25,10 +25,29 @@ import ResponseModel from '../Model/Response.model';
 export const handleError = (di, error) => {
   const logger = di.get(DEFINITIONS.LOGGER);
 
+  let errorBody = error;
+
+  if (errorBody.isAxiosError) {
+    try {
+      errorBody = {
+        config: error.config,
+        response: {
+          status: error.response.status,
+          data: error.response.data,
+        },
+      };
+    } catch {
+    // if the axios error is incomplete
+    // for any reason, we don't want
+    // error handling to fail
+      errorBody = error;
+    }
+  }
+
   if (error.raiseOnEpsagon || !error.code || error.code >= 500) {
-    logger.error(error);
+    logger.error(errorBody);
   } else {
-    logger.info(error);
+    logger.info(errorBody);
   }
 
   const responseDetails = {

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -27,16 +27,11 @@ export const handleError = (di, error) => {
 
   let errorBody = error;
 
+  // While handling an error, lambda wrapper should
+  // recognise axios errors and trim down the information
   if (errorBody.isAxiosError) {
     try {
-      // Axios errors are really verbose and
-      // local development terminals get spammed,
-      // especially if more than one test fail
-      // because of HTTP errors.
-      // While handling an error, lambda wrapper should
-      // recognise axios errors and trim down
-      // the information to the request config,
-      // response.status and response.data
+      // only keep error.config, error.response.status, error.response.data
       errorBody = {
         config: error.config,
         response: {

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -29,6 +29,14 @@ export const handleError = (di, error) => {
 
   if (errorBody.isAxiosError) {
     try {
+      // Axios errors are really verbose and
+      // local development terminals get spammed,
+      // especially if more than one test fail
+      // because of HTTP errors.
+      // While handling an error, lambda wrapper should
+      // recognise axios errors and trim down
+      // the information to the request config,
+      // response.status and response.data
       errorBody = {
         config: error.config,
         response: {

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -58,6 +58,54 @@ describe('Wrapper/LambdaWrapper', () => {
         });
       });
     });
+
+    describe('Axios Errors', () => {
+      it('Trims down the axios error', () => {
+        const di = getMockedDi();
+        const logger = di.get(DEFINITIONS.LOGGER);
+
+        const error = {
+          isAxiosError: true,
+          raiseOnEpsagon: true,
+          config: {
+            url: 'http://localhost:9999',
+            method: 'get',
+          },
+          extra: 1,
+          response: {
+            status: 417,
+            data: { data: 1 },
+            extra: 2,
+          }
+        };
+
+        const response = handleError(di, error);
+
+        const loggerCall = logger.error.mock.calls[0][0];
+
+        expect(loggerCall).toMatchSnapshot();
+        expect('extra' in loggerCall).toEqual(false);
+        expect('extra' in loggerCall.response).toEqual(false);
+      });
+
+      it('Handles an invalid axios error', () => {
+        const di = getMockedDi();
+        const logger = di.get(DEFINITIONS.LOGGER);
+
+        const error = {
+          isAxiosError: true,
+          raiseOnEpsagon: true,
+          extra: 1,
+        };
+
+        const response = handleError(di, error);
+
+        const loggerCall = logger.error.mock.calls[0][0];
+
+        expect(loggerCall).toEqual(error);
+      });
+    });
+
   });
 
   describe('LambdaWrapper', () => {

--- a/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
+++ b/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
@@ -1,17 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error 1`] = `
+exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error: EMPTY 1`] = `
 Object {
   "config": Object {
     "method": "get",
     "url": "http://localhost:9999",
   },
+  "message": "some-message",
+  "response": Object {
+    "data": undefined,
+    "status": undefined,
+  },
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error: HTTP_417 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
   "response": Object {
     "data": Object {
       "data": 1,
     },
     "status": 417,
   },
+}
+`;
+
+exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error: UNDEFINED 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
 }
 `;
 

--- a/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
+++ b/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "response": Object {
+    "data": Object {
+      "data": 1,
+    },
+    "status": 417,
+  },
+}
+`;
+
 exports[`Wrapper/LambdaWrapper handleError Generates a response object 1`] = `
 Object {
   "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",


### PR DESCRIPTION
Axios errors are really verbose and local development terminals get spammed, especially if more than one test fail because of HTTP errors.

While handling an error, lambda wrapper should recognise axios errors and trim down the information to the request config, response.status and response.data

See:
- [ENG-115]

[ENG-115]: https://comicrelief.atlassian.net/browse/ENG-115