### PR TITLE
fix: Move axios error processing in LoggerService

### DIFF
--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -25,33 +25,10 @@ import ResponseModel from '../Model/Response.model';
 export const handleError = (di, error) => {
   const logger = di.get(DEFINITIONS.LOGGER);
 
-  let errorBody = error;
-
-  // While handling an error, lambda wrapper should
-  // recognise axios errors and trim down the information
-  if (errorBody.isAxiosError) {
-    // only keep error.config, error.response.status, error.response.data
-    errorBody = {
-      config: error.config,
-      message: error.message,
-    };
-
-    // It's pretty common for axios errors
-    // to not have.response e.g.when there's
-    // a network error or timeout.
-    // These errors will have .request but not .response.
-    if (error.response) {
-      errorBody.response = {
-        status: error.response.status,
-        data: error.response.data,
-      };
-    }
-  }
-
   if (error.raiseOnEpsagon || !error.code || error.code >= 500) {
-    logger.error(errorBody);
+    logger.error(error);
   } else {
-    logger.info(errorBody);
+    logger.info(error);
   }
 
   const responseDetails = {

--- a/tests/unit/Service/__snapshots__/Logger.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/Logger.service.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Service/LoggerService error Trims down the axios error: EMPTY 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
+  "response": Object {
+    "data": undefined,
+    "status": undefined,
+  },
+}
+`;
+
+exports[`Service/LoggerService error Trims down the axios error: HTTP_417 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
+  "response": Object {
+    "data": Object {
+      "data": 1,
+    },
+    "status": 417,
+  },
+}
+`;
+
+exports[`Service/LoggerService error Trims down the axios error: UNDEFINED 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
+}
+`;
+
+exports[`Service/LoggerService info Trims down the axios error: EMPTY 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
+  "response": Object {
+    "data": undefined,
+    "status": undefined,
+  },
+}
+`;
+
+exports[`Service/LoggerService info Trims down the axios error: HTTP_417 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
+  "response": Object {
+    "data": Object {
+      "data": 1,
+    },
+    "status": 417,
+  },
+}
+`;
+
+exports[`Service/LoggerService info Trims down the axios error: UNDEFINED 1`] = `
+Object {
+  "config": Object {
+    "method": "get",
+    "url": "http://localhost:9999",
+  },
+  "message": "some-message",
+}
+`;

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -58,48 +58,6 @@ describe('Wrapper/LambdaWrapper', () => {
         });
       });
     });
-
-    describe('Axios Errors', () => {
-      const axiosResponses = {
-        UNDEFINED: undefined,
-        EMPTY: {},
-        HTTP_417: {
-          status: 417,
-          data: { data: 1 },
-          extra: 2,
-        },
-      };
-
-      Object.entries(axiosResponses).forEach(([key, axiosResponse]) => {
-        it(`Trims down the axios error: ${key}`, () => {
-          const di = getMockedDi();
-          const logger = di.get(DEFINITIONS.LOGGER);
-
-          const error = {
-            isAxiosError: true,
-            raiseOnEpsagon: true,
-            config: {
-              url: 'http://localhost:9999',
-              method: 'get',
-            },
-            extra: 1,
-            response: axiosResponse,
-            message: 'some-message',
-          };
-
-          handleError(di, error);
-
-          const loggerCall = logger.error.mock.calls[0][0];
-
-          expect(loggerCall).toMatchSnapshot();
-          expect('extra' in loggerCall).toEqual(false);
-
-          if (axiosResponse) {
-            expect('extra' in loggerCall.response).toEqual(false);
-          }
-        });
-      });
-    });
   });
 
   describe('LambdaWrapper', () => {

--- a/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
+++ b/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
@@ -1,45 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error: EMPTY 1`] = `
-Object {
-  "config": Object {
-    "method": "get",
-    "url": "http://localhost:9999",
-  },
-  "message": "some-message",
-  "response": Object {
-    "data": undefined,
-    "status": undefined,
-  },
-}
-`;
-
-exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error: HTTP_417 1`] = `
-Object {
-  "config": Object {
-    "method": "get",
-    "url": "http://localhost:9999",
-  },
-  "message": "some-message",
-  "response": Object {
-    "data": Object {
-      "data": 1,
-    },
-    "status": 417,
-  },
-}
-`;
-
-exports[`Wrapper/LambdaWrapper handleError Axios Errors Trims down the axios error: UNDEFINED 1`] = `
-Object {
-  "config": Object {
-    "method": "get",
-    "url": "http://localhost:9999",
-  },
-  "message": "some-message",
-}
-`;
-
 exports[`Wrapper/LambdaWrapper handleError Generates a response object 1`] = `
 Object {
   "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",


### PR DESCRIPTION
Services might catch the error and just log it, so it would not be
propagated at top level and pretty-printed. Extending LoggerService
takes care of those use cases.