### PR TITLE
feat: Define logger.warning function

### DIFF
--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -16,12 +16,6 @@ if (sentryIsAvailable) {
   });
 }
 
-export const LOGGING_LEVELS = {
-  dev: 'info',
-  staging: 'info',
-  production: 'error',
-};
-
 /**
  * LoggerService class
  */
@@ -208,20 +202,22 @@ export default class LoggerService extends DependencyAwareClass {
   }
 
   /**
-   * Logs an error, using logger.error
-   * or logger.info based on the logging levels
-   * that are based on the process.env.DEPLOY_ENV
+   * Logs an error, using `LoggerService.error`
+   * or `LoggerService.info` based on
+   * `process.env.LOGGER_SOFT_WARNING`.
    *
-   * Please note that LoggerService.error and LoggerService.info
+   * Please note that `LoggerService.error` and `LoggerService.info`
    * have different signatures. The function uses the shared argument
    * instead of introducing ambiguity.
    *
    * @param error
    */
   warning(error) {
-    const loggerFunction = LOGGING_LEVELS[process.env.DEPLOY_ENV] || 'error';
+    if (process.env.LOGGER_SOFT_WARNING) {
+      return this.info(error);
+    }
 
-    return this[loggerFunction](error);
+    return this.error(error);
   }
 
   /**

--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -212,6 +212,10 @@ export default class LoggerService extends DependencyAwareClass {
    * or logger.info based on the logging levels
    * that are based on the process.env.DEPLOY_ENV
    *
+   * Please note that LoggerService.error and LoggerService.info
+   * have different signatures. The function uses the shared argument
+   * instead of introducing ambiguity.
+   *
    * @param error
    */
   warning(error) {

--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -213,12 +213,11 @@ export default class LoggerService extends DependencyAwareClass {
    * that are based on the process.env.DEPLOY_ENV
    *
    * @param error
-   * @param message
    */
-  warning(error, message = '') {
+  warning(error) {
     const loggerFunction = LOGGING_LEVELS[process.env.DEPLOY_ENV] || 'error';
 
-    return this[loggerFunction](error, message);
+    return this[loggerFunction](error);
   }
 
   /**

--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -213,7 +213,9 @@ export default class LoggerService extends DependencyAwareClass {
    * @param error
    */
   warning(error) {
-    if (process.env.LOGGER_SOFT_WARNING) {
+    const softWarningValues = ['true', '1'];
+
+    if (softWarningValues.includes(process.env.LOGGER_SOFT_WARNING)) {
       return this.info(error);
     }
 

--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -16,6 +16,12 @@ if (sentryIsAvailable) {
   });
 }
 
+export const LOGGING_LEVELS = {
+  dev: 'info',
+  staging: 'info',
+  production: 'error',
+};
+
 /**
  * LoggerService class
  */
@@ -199,6 +205,20 @@ export default class LoggerService extends DependencyAwareClass {
    */
   info(message) {
     this.logger.log('info', this.processMessage(message));
+  }
+
+  /**
+   * Logs an error, using logger.error
+   * or logger.info based on the logging levels
+   * that are based on the process.env.DEPLOY_ENV
+   *
+   * @param error
+   * @param message
+   */
+  warning(error, message = '') {
+    const loggerFunction = LOGGING_LEVELS[process.env.DEPLOY_ENV] || 'error';
+
+    return this[loggerFunction](error, message);
   }
 
   /**

--- a/tests/unit/Service/Logger.service.test.js
+++ b/tests/unit/Service/Logger.service.test.js
@@ -135,19 +135,23 @@ describe('Service/LoggerService', () => {
   });
 
   describe('warning', () => {
-    let DEPLOY_ENV;
+    let LOGGER_SOFT_WARNING;
 
     beforeAll(() => {
-      DEPLOY_ENV = process.env.DEPLOY_ENV;
+      LOGGER_SOFT_WARNING = process.env.LOGGER_SOFT_WARNING;
     });
 
     afterAll(() => {
-      process.env.DEPLOY_ENV = DEPLOY_ENV;
+      process.env.LOGGER_SOFT_WARNING = LOGGER_SOFT_WARNING;
     });
 
-    Object.entries(LOGGING_LEVELS).forEach(([deployEnv, func]) => {
-      it(`uses 'this.logger.${func}' in ${deployEnv}`, () => {
-        process.env.DEPLOY_ENV = deployEnv;
+    [
+      ['', 'error'],
+      ['1', 'info'],
+      ['true', 'info'],
+    ].forEach(([loggerSoftWarning, func]) => {
+      it(`uses 'this.logger.${func}' in ${loggerSoftWarning}`, () => {
+        process.env.LOGGER_SOFT_WARNING = loggerSoftWarning;
         const logger = getLogger();
 
         jest.spyOn(logger, func).mockImplementation(() => {});
@@ -155,19 +159,6 @@ describe('Service/LoggerService', () => {
         logger.warning({});
 
         expect(logger[func]).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    ['', undefined, 'INVALID_VALUE'].forEach((deployEnv) => {
-      it(`Defaults to this.logger.error if process.env.DEPLOY_ENV is ${deployEnv}`, () => {
-        process.env.DEPLOY_ENV = deployEnv;
-        const logger = getLogger();
-
-        jest.spyOn(logger, 'error').mockImplementation(() => {});
-
-        logger.warning({});
-
-        expect(logger.error).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/tests/unit/Service/Logger.service.test.js
+++ b/tests/unit/Service/Logger.service.test.js
@@ -147,7 +147,12 @@ describe('Service/LoggerService', () => {
 
     [
       ['', 'error'],
+      ['some-value', 'error'],
+      [false, 'error'],
+      ['false', 'error'],
+      ['0', 'error'],
       ['1', 'info'],
+      [true, 'info'],
       ['true', 'info'],
     ].forEach(([loggerSoftWarning, func]) => {
       it(`uses 'this.logger.${func}' in ${loggerSoftWarning}`, () => {

--- a/tests/unit/Service/Logger.service.test.js
+++ b/tests/unit/Service/Logger.service.test.js
@@ -152,7 +152,7 @@ describe('Service/LoggerService', () => {
 
         jest.spyOn(logger, func).mockImplementation(() => {});
 
-        logger.warning({}, '');
+        logger.warning({});
 
         expect(logger[func]).toHaveBeenCalledTimes(1);
       });
@@ -165,7 +165,7 @@ describe('Service/LoggerService', () => {
 
         jest.spyOn(logger, 'error').mockImplementation(() => {});
 
-        logger.warning({}, '');
+        logger.warning({});
 
         expect(logger.error).toHaveBeenCalledTimes(1);
       });

--- a/tests/unit/Service/Logger.service.test.js
+++ b/tests/unit/Service/Logger.service.test.js
@@ -1,7 +1,7 @@
 import Winston from 'winston';
 
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
-import LoggerService, { LOGGING_LEVELS } from '../../../src/Service/Logger.service';
+import LoggerService from '../../../src/Service/Logger.service';
 import CONFIGURATION from '../../../src/Config/Dependencies';
 
 const getEvent = require('../../mocks/aws/event.json');


### PR DESCRIPTION
I have been thinking on how logger.error gets in the way of testing. I believe failures should be as noisy as they can be, and also that they should be tested.

When it comes to test a function failure that has the side effect of calling logger.error what we really want to observe is some kind of error handling (i.e. the function forces the lambda to return a form of HTTP 4xx). In production usage, we might want to trigger logger.error. This is even more true when the lambda is triggered by SQS. The reason is that we want to log the error to Epsagon while not necessarily fail the function (especially if we are processing several messages in one call).

Enter feature tests. The behaviour above is all good for production, but when running integration tests it spams Epsagon with false positives. Staging functions are full of errors that are triggered on purpose by feature tests (checking that things fail nicely) . This is noise that don't help us on keeping track of real errors that might slip through our attention.

My proposal is to add a logger.warning function that checks the
environment (process.env.DEPLOY_ENV) and calls logger.error in
production and logger.info otherwise - This is easier to manage (we
don't need to deal with SQS or downstream failures) but introduces a
difference between staging and production.

See:
- [ENG-125]

[ENG-125]: https://comicrelief.atlassian.net/browse/ENG-125