### PR TITLE
feat: Define lambda-wrapper status helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "^7.11.5",
     "@comicrelief/eslint-config": "^1.2.1",
+    "@types/jest": "^26.0.20",
     "aws-sdk": ">=2.743.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.3.0",

--- a/src/Service/BaseConfig.service.js
+++ b/src/Service/BaseConfig.service.js
@@ -1,0 +1,145 @@
+import { S3 } from 'aws-sdk';
+
+import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
+
+export const S3_NO_SUCH_KEY_ERROR_CODE = 'NoSuchKey';
+
+export const ServiceStates = {
+  OK: 'OK',
+  TEMPORARY_PAUSED: 'TEMPORARY_PAUSED',
+  UNDEFINITELY_PAUSED: 'UNDEFINITELY_PAUSED',
+};
+
+/**
+ * BaseConfigService class
+ *
+ * This class is to be extended by the implementing service
+ * so that `defaultConfig` and possibly `s3Config` can be
+ * overriden / extended.
+ */
+export default class BaseConfigService extends DependencyAwareClass {
+  /**
+   * Returns the basic config.
+   * This getter is used to set the config
+   * should the service not find any
+   * on the configured S3 Bucket.
+   */
+  static get defaultConfig() {
+    return {
+      state: ServiceStates.OK,
+    };
+  }
+
+  /**
+   * Returns the S3 configuration
+   * used to retrieve / update the
+   * service configuration.
+   */
+  static get s3config() {
+    return {
+      Bucket: process.env.SERVICE_CONFIG_S3_BUCKET,
+      Key: process.env.SERVICE_CONFIG_S3_KEY,
+    };
+  }
+
+  /**
+   * Returns an S3 client
+   *
+   * @returns {S3}
+   */
+  static get client() {
+    return new S3({
+      region: process.env.REGION,
+    });
+  }
+
+  /**
+   * Returns an S3 client
+   *
+   * @returns {S3}
+   */
+  get client() {
+    return this.constructor.client;
+  }
+
+  /**
+   * Puts the given configuration on S3
+   *
+   * @param config
+   */
+  async put(config) {
+    await this.client.putObject({
+      ...this.constructor.s3config,
+      Body: JSON.stringify(config),
+    });
+
+    return config;
+  }
+
+  /**
+   * Gets the service configuration.
+   */
+  async get() {
+    const response = await this.client.getObject(this.constructor.s3config).promise();
+    const body = String(response.Body);
+
+    if (!body) {
+      // Empty strings are not valid configurations
+      throw new Error('Configuration file is empty.');
+    }
+
+    try {
+      return JSON.parse(body);
+    } catch {
+      throw new Error('Invalid configuration file');
+    }
+  }
+
+  /**
+   * Gets or creates the service configuration.
+   *
+   * If the configuration is not found on S3
+   * the default configuration
+   * is uploaded and returned instead.
+   */
+  async getOrCreate() {
+    try {
+      return await this.get();
+    } catch (error) {
+      if (error.code !== S3_NO_SUCH_KEY_ERROR_CODE) {
+        // Throw directly any other error
+        throw error;
+      }
+
+      return this.put(this.constructor.defaultConfig);
+    }
+  }
+
+  /**
+   * Patches the existing configuration
+   * or the default configuration
+   * with the provided partial configuration
+   *
+   * @param partialConfig
+   */
+  async patch(partialConfig) {
+    let base = this.constructor.defaultConfig;
+
+    try {
+      base = await this.get();
+    } catch (error) {
+      if (error.code !== S3_NO_SUCH_KEY_ERROR_CODE) {
+        // Throw directly any other error
+        throw error;
+      }
+
+      // Config doesn't exist
+      // keep using `this.constructor.defaultConfig`
+    }
+
+    return this.put({
+      ...base,
+      ...partialConfig,
+    });
+  }
+}

--- a/src/Service/BaseConfig.service.js
+++ b/src/Service/BaseConfig.service.js
@@ -2,27 +2,35 @@ import { S3 } from 'aws-sdk';
 
 import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
 
+/**
+ * Error.code for S3 404 errors
+ */
 export const S3_NO_SUCH_KEY_ERROR_CODE = 'NoSuchKey';
 
+/**
+ * Represents the service states
+ */
 export const ServiceStates = {
   OK: 'OK',
   TEMPORARY_PAUSED: 'TEMPORARY_PAUSED',
-  UNDEFINITELY_PAUSED: 'UNDEFINITELY_PAUSED',
+  INDEFINITELY_PAUSED: 'UNDEFINITELY_PAUSED',
 };
 
 /**
  * BaseConfigService class
  *
- * This class is to be extended by the implementing service
+ * This class is to be extended by the implementing services
  * so that `defaultConfig` and possibly `s3Config` can be
  * overriden / extended.
  */
 export default class BaseConfigService extends DependencyAwareClass {
   /**
    * Returns the basic config.
-   * This getter is used to set the config
+   * This getter is used to set the default config
    * should the service not find any
    * on the configured S3 Bucket.
+   *
+   * See `getOrCreate` and `patch` methods.
    */
   static get defaultConfig() {
     return {
@@ -85,7 +93,7 @@ export default class BaseConfigService extends DependencyAwareClass {
 
     if (!body) {
       // Empty strings are not valid configurations
-      throw new Error('Configuration file is empty.');
+      throw new Error('Configuration file is empty');
     }
 
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export { default as SQSMessageModel } from './Model/SQS/Message.model';
 export { default as MarketingPreferenceModel } from './Model/SQS/MarketingPreference.model';
 
 // Service
+export { default as BaseConfigService } from './Service/BaseConfig.service';
 export { default as LoggerService } from './Service/Logger.service';
 export { default as RequestService } from './Service/Request.service';
 export { default as SQSService } from './Service/SQS.service';

--- a/tests/unit/Service/BaseConfig.service.test.js
+++ b/tests/unit/Service/BaseConfig.service.test.js
@@ -1,0 +1,191 @@
+import { S3 } from 'aws-sdk';
+import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
+import BaseConfigService, { S3_NO_SUCH_KEY_ERROR_CODE } from '../../../src/Service/BaseConfig.service';
+
+const createAsyncMock = (returnValue) => {
+  const mockedValue = returnValue instanceof Error
+    ? Promise.reject(returnValue)
+    : Promise.resolve(returnValue);
+
+  return jest.fn().mockReturnValue({ promise: () => mockedValue });
+};
+
+/**
+ * Generates a BaseConfigService
+ *
+ * @param {*} param0
+ * @returns {BaseConfigService}
+ */
+const getService = ({ getObject = null, putObject = null } = {}) => {
+  const di = new DependencyInjection({});
+  const service = new BaseConfigService(di);
+  const client = {
+    getObject: createAsyncMock(getObject),
+    putObject: createAsyncMock(putObject),
+  };
+
+  jest.spyOn(service, 'client', 'get').mockReturnValue(client);
+
+  return service;
+};
+
+const BaseConfigUnitTests = (serviceGenerator: (...args) => BaseConfigService) => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('defaultConfig', () => {
+    it('is a valid object', () => {
+      const service = serviceGenerator();
+      const isValidObject = typeof service.constructor.defaultConfig === 'object' && service.constructor.defaultConfig !== null;
+
+      expect(isValidObject).toEqual(true);
+    });
+
+    it('has state defined', () => {
+      const service = serviceGenerator();
+      const defaultConfig = service.constructor.defaultConfig;
+
+      expect('state' in defaultConfig).toEqual(true);
+    });
+  });
+
+  describe('s3config', () => {
+    it('is a valid object', () => {
+      const service = serviceGenerator();
+      const isValidObject = typeof service.constructor.s3config === 'object' && service.constructor.s3config !== null;
+
+      expect(isValidObject).toEqual(true);
+    });
+
+    it('has Bucket and Key defined', () => {
+      const service = serviceGenerator();
+      const s3config = service.constructor.s3config;
+
+      expect('Bucket' in s3config).toEqual(true);
+      expect('Key' in s3config).toEqual(true);
+    });
+  });
+
+  describe('put', () => {
+    it('calls client.putObject', async () => {
+      const expected = Symbol('put');
+      const service = serviceGenerator();
+      await service.put(expected);
+
+      expect(service.client.putObject).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the provided config unchanged', async () => {
+      const expected = Symbol('put');
+      const service = serviceGenerator();
+      const config = await service.put(expected);
+
+      expect(config).toEqual(expected);
+    });
+  });
+
+  describe('get', () => {
+    it('gets an existing config', async () => {
+      const expected = { a: 1 };
+      const service = serviceGenerator({ getObject: { Body: JSON.stringify(expected) } });
+      const config = await service.get();
+
+      expect(config).toEqual(expected);
+    });
+
+    it('refuses empty configurations', async () => {
+      const service = serviceGenerator({ getObject: { Body: '' } });
+
+      await expect(service.get()).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    it('refuses invalid configurations', async () => {
+      const service = serviceGenerator({ getObject: { Body: '{ "a": 1' } });
+
+      await expect(service.get()).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    it('propagates the 404', async () => {
+      const error = new Error('404');
+      error.code = S3_NO_SUCH_KEY_ERROR_CODE;
+
+      const service = serviceGenerator({ getObject: error });
+
+      await expect(service.get()).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('getOrCreate', () => {
+    it('uploads the defaultConfig with a 404 error', async () => {
+      const error = new Error('404');
+      error.code = S3_NO_SUCH_KEY_ERROR_CODE;
+
+      const service = serviceGenerator({ getObject: error });
+      const config = await service.getOrCreate();
+
+      expect(config).toEqual(service.constructor.defaultConfig);
+    });
+
+    it('throws any non-404 error', async () => {
+      const error = new Error('Bad error');
+      error.code = 'another';
+
+      const service = serviceGenerator({ getObject: error });
+
+      await expect(service.getOrCreate()).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('patch', () => {
+    it('uses the existing config if an existing config is found', async () => {
+      const existing = { a: 1 };
+      const service = serviceGenerator({ getObject: { Body: JSON.stringify(existing) } });
+
+      const additional = { b: 2 };
+      const expected = { ...existing, ...additional };
+      const config = await service.patch(additional);
+
+      expect(config).toEqual(expected);
+    });
+
+    it('uses the base config if no existing config is found', async () => {
+      const error = new Error('404');
+      error.code = S3_NO_SUCH_KEY_ERROR_CODE;
+      const service = serviceGenerator({ getObject: error });
+
+      const existing = service.constructor.defaultConfig;
+      const additional = { b: 2 };
+      const expected = { ...existing, ...additional };
+      const config = await service.patch(additional);
+
+      expect(config).toEqual(expected);
+    });
+
+    it('throws any non-404 error', async () => {
+      const error = new Error('Bad error');
+      error.code = 'another';
+
+      const service = serviceGenerator({ getObject: error });
+
+      await expect(service.patch({ b: 1 })).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+};
+
+describe('Service/BaseConfigService', () => {
+  BaseConfigUnitTests(getService);
+
+  describe('client', () => {
+    it('Returns an s3 instance (static)', () => {
+      expect(BaseConfigService.client instanceof S3).toEqual(true);
+    });
+
+    it('Returns an s3 instance', () => {
+      const di = new DependencyInjection({});
+      const service = new BaseConfigService(di);
+
+      expect(service.client instanceof S3).toEqual(true);
+    });
+  });
+});

--- a/tests/unit/Service/__snapshots__/BaseConfig.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/BaseConfig.service.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Service/BaseConfigService get propagates the 404 1`] = `"404"`;
 
-exports[`Service/BaseConfigService get refuses empty configurations 1`] = `"Configuration file is empty."`;
+exports[`Service/BaseConfigService get refuses empty configurations 1`] = `"Configuration file is empty"`;
 
 exports[`Service/BaseConfigService get refuses invalid configurations 1`] = `"Invalid configuration file"`;
 

--- a/tests/unit/Service/__snapshots__/BaseConfig.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/BaseConfig.service.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Service/BaseConfigService get propagates the 404 1`] = `"404"`;
+
+exports[`Service/BaseConfigService get refuses empty configurations 1`] = `"Configuration file is empty."`;
+
+exports[`Service/BaseConfigService get refuses invalid configurations 1`] = `"Invalid configuration file"`;
+
+exports[`Service/BaseConfigService getOrCreate throws any non-404 error 1`] = `"Bad error"`;
+
+exports[`Service/BaseConfigService patch throws any non-404 error 1`] = `"Bad error"`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -1913,6 +1924,14 @@
   integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^26.0.20":
+  version "26.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
+  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/js-yaml@^3.12.1":
   version "3.12.5"
@@ -3820,6 +3839,11 @@ diff-sequences@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.3.0.tgz#62a59b1b29ab7fd27cef2a33ae52abe73042d0a2"
   integrity sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==
+
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
@@ -6131,6 +6155,16 @@ jest-config@^26.4.2:
     jest-validate "^26.4.2"
     micromatch "^4.0.2"
     pretty-format "^26.4.2"
+
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
 
 jest-diff@^26.4.2:
   version "26.4.2"
@@ -8739,6 +8773,16 @@ pretty-bytes@^5.1.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
   integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^26.4.2:
   version "26.4.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
@@ -8988,6 +9032,11 @@ react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 read-cmd-shim@^1.0.1, read-cmd-shim@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Instead of reproducing the service status get and service status set logic across several services, Lambda Wrapper will define a Status service that handles these two operations for us.

See:
- [ENG-153]
- [ENG-164]

[ENG-153]: https://comicrelief.atlassian.net/browse/ENG-153
[ENG-164]: https://comicrelief.atlassian.net/browse/ENG-164