### PR TITLE
chore: Lint imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-flow": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "^7.11.5",
-    "@comicrelief/eslint-config": "^1.2.1",
+    "@comicrelief/eslint-config": "^1.3.0",
     "@types/jest": "^26.0.20",
     "aws-sdk": ">=2.743.0",
     "babel-eslint": "^10.1.0",

--- a/src/Model/CloudEvent.model.js
+++ b/src/Model/CloudEvent.model.js
@@ -1,4 +1,5 @@
 import { v4 as UUID } from 'uuid';
+
 import Model from './Model.model';
 
 /**

--- a/src/Model/SQS/MarketingPreference.model.js
+++ b/src/Model/SQS/MarketingPreference.model.js
@@ -1,8 +1,9 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import validate from 'validate.js';
+
 import Model from '../Model.model';
-import requestConstraints from './MarketingPreference.constraints.json';
 import ResponseModel from '../Response.model';
+import requestConstraints from './MarketingPreference.constraints.json';
 
 // Define action specific error types
 export const ERROR_TYPES = {

--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -1,6 +1,6 @@
-import Winston from 'winston';
 import * as Sentry from '@sentry/node';
 import Epsagon from 'epsagon';
+import Winston from 'winston';
 
 import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
 import DependencyInjection from '../DependencyInjection/DependencyInjection.class';

--- a/src/Service/Request.service.js
+++ b/src/Service/Request.service.js
@@ -2,13 +2,14 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* @flow */
 import QueryString from 'querystring';
+
+import useragent from 'useragent';
 import validate from 'validate.js/validate';
 import XML2JS from 'xml2js';
-import useragent from 'useragent';
 
+import { DEFINITIONS } from '../Config/Dependencies';
 import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
 import ResponseModel from '../Model/Response.model';
-import { DEFINITIONS } from '../Config/Dependencies';
 
 export const REQUEST_TYPES = {
   GET: 'GET',

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -1,15 +1,14 @@
 /* @flow */
 import Alai from 'alai';
-import AWS from 'aws-sdk';
 import each from 'async/each';
+import AWS from 'aws-sdk';
 import { v4 as UUID } from 'uuid';
 
+import { DEFINITIONS } from '../Config/Dependencies';
 import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
 import DependencyInjection from '../DependencyInjection/DependencyInjection.class';
-import StatusModel, { STATUS_TYPES } from '../Model/Status.model';
 import SQSMessageModel from '../Model/SQS/Message.model';
-
-import { DEFINITIONS } from '../Config/Dependencies';
+import StatusModel, { STATUS_TYPES } from '../Model/Status.model';
 
 // Set a timeout on S3 in case of outage
 AWS.Config.httpOptions = {

--- a/src/Service/Timer.service.js
+++ b/src/Service/Timer.service.js
@@ -1,6 +1,6 @@
+import { DEFINITIONS } from '../Config/Dependencies';
 import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
 import DependencyInjection from '../DependencyInjection/DependencyInjection.class';
-import { DEFINITIONS } from '../Config/Dependencies';
 
 /**
  * TimerService class

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -1,8 +1,8 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import Epsagon from 'epsagon';
 
-import DependencyInjection from '../DependencyInjection/DependencyInjection.class';
 import { DEFINITIONS } from '../Config/Dependencies';
+import DependencyInjection from '../DependencyInjection/DependencyInjection.class';
 import ResponseModel from '../Model/Response.model';
 
 /**

--- a/tests/unit/DependencyInjection/DependencyAware.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyAware.class.test.js
@@ -1,8 +1,10 @@
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
+// The import order is relevant here to avoid circular imports
+// eslint-disable-next-line import/order
 import DependencyAware from '../../../src/DependencyInjection/DependencyAware.class';
 
-const getEvent = require('../../mocks/aws/event.json');
 const getContext = require('../../mocks/aws/context.json');
+const getEvent = require('../../mocks/aws/event.json');
 
 describe('DependencyInjection/DependencyAwareClass', () => {
   describe('getContainer', () => {

--- a/tests/unit/DependencyInjection/DependencyInjection.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyInjection.class.test.js
@@ -1,11 +1,10 @@
-import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import { DEFINITIONS } from '../../../src/Config/Dependencies';
-
-import RequestService from '../../../src/Service/Request.service';
+import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import LoggerService from '../../../src/Service/Logger.service';
+import RequestService from '../../../src/Service/Request.service';
 
-const getEvent = require('../../mocks/aws/event.json');
 const getContext = require('../../mocks/aws/context.json');
+const getEvent = require('../../mocks/aws/event.json');
 
 describe('DependencyInjection/DependencyInjectionClass', () => {
   describe('should instantiate', () => {

--- a/tests/unit/Model/SQS/MarketingPreferences.model.test.js
+++ b/tests/unit/Model/SQS/MarketingPreferences.model.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
-import MarketingPreferencesModel from '../../../../src/Model/SQS/MarketingPreference.model';
 import ResponseModel from '../../../../src/Model/Response.model';
+import MarketingPreferencesModel from '../../../../src/Model/SQS/MarketingPreference.model';
 
 // Test definitions.
 describe('Model/MarketingPreferencesModel', () => {

--- a/tests/unit/Service/BaseConfig.service.test.js
+++ b/tests/unit/Service/BaseConfig.service.test.js
@@ -1,4 +1,5 @@
 import { S3 } from 'aws-sdk';
+
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import BaseConfigService, { S3_NO_SUCH_KEY_ERROR_CODE } from '../../../src/Service/BaseConfig.service';
 

--- a/tests/unit/Service/Logger.service.test.js
+++ b/tests/unit/Service/Logger.service.test.js
@@ -1,8 +1,8 @@
 import Winston from 'winston';
 
+import CONFIGURATION from '../../../src/Config/Dependencies';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import LoggerService from '../../../src/Service/Logger.service';
-import CONFIGURATION from '../../../src/Config/Dependencies';
 
 const getEvent = require('../../mocks/aws/event.json');
 

--- a/tests/unit/Service/Request.service.test.js
+++ b/tests/unit/Service/Request.service.test.js
@@ -3,12 +3,12 @@ import QueryString from 'querystring';
 
 import sinon from 'sinon';
 
+import CONFIGURATION from '../../../src/Config/Dependencies';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import RequestService, { REQUEST_TYPES } from '../../../src/Service/Request.service';
-import CONFIGURATION from '../../../src/Config/Dependencies';
 
-const getEvent = require('../../mocks/aws/event.json');
 const getContext = require('../../mocks/aws/context.json');
+const getEvent = require('../../mocks/aws/event.json');
 
 describe('Service/RequestService', () => {
   afterEach(() => sinon.restore());

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -1,14 +1,14 @@
 import sinon from 'sinon';
 
 import { DEFINITIONS } from '../../../src/Config/Dependencies';
-import RequestService, { REQUEST_TYPES } from '../../../src/Service/Request.service';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
-import LambdaWrapper, { handleError } from '../../../src/Wrapper/LambdaWrapper';
+import RequestService, { REQUEST_TYPES } from '../../../src/Service/Request.service';
 import LambdaTermination from '../../../src/Wrapper/LambdaTermination';
+import LambdaWrapper, { handleError } from '../../../src/Wrapper/LambdaWrapper';
 import { getMockedDi } from '../../lib/mocks';
 
-const getEvent = require('../../mocks/aws/event.json');
 const getContext = require('../../mocks/aws/context.json');
+const getEvent = require('../../mocks/aws/event.json');
 
 describe('Wrapper/LambdaWrapper', () => {
   let dependencyInjection = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@comicrelief/eslint-config@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@comicrelief/eslint-config/-/eslint-config-1.2.1.tgz#97ac8b7a4ad3c729d663b2fefdc6fdc3889a7584"
-  integrity sha512-Pk7JjeyP0o72URKVTcSx9TAayrOedr445vdIAciifE6SnXZsCAu3gmipSHBq677MzQarKW+GIufU705x2RNdAg==
+"@comicrelief/eslint-config@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@comicrelief/eslint-config/-/eslint-config-1.3.0.tgz#d22cc8d915e7bdade37a174fa20b835bd93e146b"
+  integrity sha512-50JbY2qvwPD2R0vr+PQyCCb+nhNXG7kJL1Q+raeBvgT0LRjc/qQolab1F+Ei67H/poXSU7p/JUCqX256CJUJXw==
   dependencies:
     "@babel/eslint-parser" ">=7.11.3"
     "@typescript-eslint/parser" "^4.7.0"


### PR DESCRIPTION
Upgrading to @comicrelief/eslint-config lets us lint imports, sorting
them in logical groups.