### PR TITLE
fix: Add ability to log objects easily

### DIFF
--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -264,4 +264,21 @@ export default class LoggerService extends DependencyAwareClass {
       this.logger.log('info', `metric - ${descriptor} - ${stat}`);
     }
   }
+
+  /**
+   * Logs an object so that it can be inspected
+   *
+   * @param action - What are we doing with the object, i.e. 'Processing'
+   * @param object - The object to be stored in logs
+   * @param level - 'error', 'warning' or 'info'
+   */
+  object(action, object, level = 'info') {
+    if (!(['error', 'warning', 'info'].includes(level))) {
+      throw new Error('Unrecognised log level');
+    }
+
+    const payload = JSON.stringify(object, null, 4);
+
+    return this[level](`${action}: '${payload}'`);
+  }
 }

--- a/tests/unit/Service/Logger.service.test.js
+++ b/tests/unit/Service/Logger.service.test.js
@@ -167,4 +167,26 @@ describe('Service/LoggerService', () => {
       });
     });
   });
+
+  describe('object', () => {
+    ['error', 'warning', 'info'].forEach((level) => {
+      [
+        null,
+        'a string',
+        { a: 1 },
+        { a: { b: null }, c: 'a string' },
+      ].forEach((object) => {
+        it(`Logs a '${JSON.stringify(object)}' with level: '${level}'`, () => {
+          const logger = getLogger();
+          let message;
+
+          jest.spyOn(logger, level).mockImplementation((arg) => { message = arg; });
+
+          logger.object('My action', object, level);
+          expect(logger[level]).toHaveBeenCalledTimes(1);
+          expect(message).toMatchSnapshot();
+        });
+      });
+    });
+  });
 });

--- a/tests/unit/Service/__snapshots__/Logger.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/Logger.service.test.js.snap
@@ -79,3 +79,60 @@ Object {
   "message": "some-message",
 }
 `;
+
+exports[`Service/LoggerService object Logs a '"a string"' with level: 'error' 1`] = `"My action: '\\"a string\\"'"`;
+
+exports[`Service/LoggerService object Logs a '"a string"' with level: 'info' 1`] = `"My action: '\\"a string\\"'"`;
+
+exports[`Service/LoggerService object Logs a '"a string"' with level: 'warning' 1`] = `"My action: '\\"a string\\"'"`;
+
+exports[`Service/LoggerService object Logs a '{"a":{"b":null},"c":"a string"}' with level: 'error' 1`] = `
+"My action: '{
+    \\"a\\": {
+        \\"b\\": null
+    },
+    \\"c\\": \\"a string\\"
+}'"
+`;
+
+exports[`Service/LoggerService object Logs a '{"a":{"b":null},"c":"a string"}' with level: 'info' 1`] = `
+"My action: '{
+    \\"a\\": {
+        \\"b\\": null
+    },
+    \\"c\\": \\"a string\\"
+}'"
+`;
+
+exports[`Service/LoggerService object Logs a '{"a":{"b":null},"c":"a string"}' with level: 'warning' 1`] = `
+"My action: '{
+    \\"a\\": {
+        \\"b\\": null
+    },
+    \\"c\\": \\"a string\\"
+}'"
+`;
+
+exports[`Service/LoggerService object Logs a '{"a":1}' with level: 'error' 1`] = `
+"My action: '{
+    \\"a\\": 1
+}'"
+`;
+
+exports[`Service/LoggerService object Logs a '{"a":1}' with level: 'info' 1`] = `
+"My action: '{
+    \\"a\\": 1
+}'"
+`;
+
+exports[`Service/LoggerService object Logs a '{"a":1}' with level: 'warning' 1`] = `
+"My action: '{
+    \\"a\\": 1
+}'"
+`;
+
+exports[`Service/LoggerService object Logs a 'null' with level: 'error' 1`] = `"My action: 'null'"`;
+
+exports[`Service/LoggerService object Logs a 'null' with level: 'info' 1`] = `"My action: 'null'"`;
+
+exports[`Service/LoggerService object Logs a 'null' with level: 'warning' 1`] = `"My action: 'null'"`;


### PR DESCRIPTION
Sometimes we want to log an object, i.e. "Processing: X", but there is a
lot of boilerplate involved each time, as we need to JSON.stringify the
object and put the result in a template string.

The `.object` method will cut the boilerplate for us.