### PR TITLE
fix(BaseConfig): Await the putObject request

### DIFF
--- a/src/Service/BaseConfig.service.js
+++ b/src/Service/BaseConfig.service.js
@@ -71,6 +71,14 @@ export default class BaseConfigService extends DependencyAwareClass {
   }
 
   /**
+   * Deletes the configuration stored on S3.
+   * Helpful in feature tests.
+   */
+  async delete() {
+    return this.client.deleteObject(this.constructor.s3config).promise();
+  }
+
+  /**
    * Puts the given configuration on S3
    *
    * @param config
@@ -79,7 +87,8 @@ export default class BaseConfigService extends DependencyAwareClass {
     await this.client.putObject({
       ...this.constructor.s3config,
       Body: JSON.stringify(config),
-    });
+    })
+      .promise();
 
     return config;
   }

--- a/tests/unit/Service/BaseConfig.service.test.js
+++ b/tests/unit/Service/BaseConfig.service.test.js
@@ -76,14 +76,6 @@ const BaseConfigUnitTests = (serviceGenerator: (...args) => BaseConfigService) =
 
       expect(service.client.deleteObject).toHaveBeenCalledTimes(1);
     });
-
-    it('returns the provided config unchanged', async () => {
-      const expected = Symbol('put');
-      const service = serviceGenerator();
-      const config = await service.put(expected);
-
-      expect(config).toEqual(expected);
-    });
   });
 
   describe('put', () => {

--- a/tests/unit/Service/BaseConfig.service.test.js
+++ b/tests/unit/Service/BaseConfig.service.test.js
@@ -17,12 +17,13 @@ const createAsyncMock = (returnValue) => {
  * @param {*} param0
  * @returns {BaseConfigService}
  */
-const getService = ({ getObject = null, putObject = null } = {}) => {
+const getService = ({ getObject = null, putObject = null, deleteObject = null } = {}) => {
   const di = new DependencyInjection({});
   const service = new BaseConfigService(di);
   const client = {
     getObject: createAsyncMock(getObject),
     putObject: createAsyncMock(putObject),
+    deleteObject: createAsyncMock(deleteObject),
   };
 
   jest.spyOn(service, 'client', 'get').mockReturnValue(client);
@@ -65,6 +66,23 @@ const BaseConfigUnitTests = (serviceGenerator: (...args) => BaseConfigService) =
 
       expect('Bucket' in s3config).toEqual(true);
       expect('Key' in s3config).toEqual(true);
+    });
+  });
+
+  describe('delete', () => {
+    it('calls client.deleteObject', async () => {
+      const service = serviceGenerator();
+      await service.delete();
+
+      expect(service.client.deleteObject).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the provided config unchanged', async () => {
+      const expected = Symbol('put');
+      const service = serviceGenerator();
+      const config = await service.put(expected);
+
+      expect(config).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
In the `aws-sdk` if you don't pass a callback to the operation AND you
don't await the `.promise()` the operation is not really executed and
fails silently.