### PR TITLE
feat: Implement HealthCheck functionality

### DIFF
--- a/src/Service/BaseConfig.service.js
+++ b/src/Service/BaseConfig.service.js
@@ -1,7 +1,7 @@
 import { S3 } from 'aws-sdk';
 
 import DependencyAwareClass from '../DependencyInjection/DependencyAware.class';
-
+import LambdaTermination from '../Wrapper/LambdaTermination';
 /**
  * Error.code for S3 404 errors
  */
@@ -14,6 +14,15 @@ export const ServiceStates = {
   OK: 'OK',
   TEMPORARY_PAUSED: 'TEMPORARY_PAUSED',
   INDEFINITELY_PAUSED: 'UNDEFINITELY_PAUSED',
+};
+
+/**
+ * Maps service states to HTTP codes
+ */
+export const ServiceStatesHttpCodes = {
+  [ServiceStates.OK]: 200,
+  [ServiceStates.TEMPORARY_PAUSED]: 409,
+  [ServiceStates.INDEFINITELY_PAUSED]: 409,
 };
 
 /**
@@ -158,5 +167,38 @@ export default class BaseConfigService extends DependencyAwareClass {
       ...base,
       ...partialConfig,
     });
+  }
+
+  /**
+   * Performs an health check
+   * given the currentConfig.
+   *
+   * If currentConfig is not supplied
+   * it uses `getOrCreate` to fetch it.
+   *
+   * @param currentConfig
+   */
+  async healthCheck(currentConfig = null) {
+    const config = currentConfig || await this.getOrCreate();
+
+    return ServiceStatesHttpCodes[config.state] || 500;
+  }
+
+  /**
+   * Ensures that the application is healthy
+   * or throws a LambdaTermination
+   *
+   * @param currentConfig
+   */
+  async ensureHealthy(currentConfig = null) {
+    const statusCode = await this.healthCheck(currentConfig);
+
+    if (statusCode < 400) {
+      return statusCode;
+    }
+
+    const message = 'Application is not healthy.';
+
+    throw new LambdaTermination(message, statusCode, message, message);
   }
 }

--- a/src/Service/BaseConfig.service.js
+++ b/src/Service/BaseConfig.service.js
@@ -170,7 +170,7 @@ export default class BaseConfigService extends DependencyAwareClass {
   }
 
   /**
-   * Performs an health check
+   * Performs a health check
    * given the currentConfig.
    *
    * If currentConfig is not supplied

--- a/tests/unit/Service/__snapshots__/BaseConfig.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/BaseConfig.service.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Service/BaseConfigService ensureHealthy 400 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 401 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 403 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 404 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 409 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 499 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 500 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 501 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 502 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 503 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy 504 throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
+exports[`Service/BaseConfigService ensureHealthy Dante Alighieri throws a LambdaTermination 1`] = `"Application is not healthy."`;
+
 exports[`Service/BaseConfigService get propagates the 404 1`] = `"404"`;
 
 exports[`Service/BaseConfigService get refuses empty configurations 1`] = `"Configuration file is empty"`;


### PR DESCRIPTION
It is a common task to health check an application at start up and force an early failure. The health check logic should be based on LambdaWrapper and extended in each application.

See:
- [ENG-210]

[ENG-210]: https://comicrelief.atlassian.net/browse/ENG-210