### PR TITLE
fix: Avoid throwing unhandled exceptions to preserve Epsagon traces

### DIFF
--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -54,6 +54,10 @@ export const handleError = (di, error, throwError = false) => {
       return error;
     }
 
+    // We want to be absolutely sure
+    // that we are returning an error
+    // as Lambda sync handlers will only fail
+    // if the object is instanceof Error
     return new Error(error);
   }
 

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -41,7 +41,7 @@ export const handleSuccess = (di, outcome) => {
 export const handleError = (di, error, throwError = false) => {
   const logger = di.get(DEFINITIONS.LOGGER);
 
-  logger.metric('lambda.returnCode', error.code || 500);
+  logger.metric('lambda.statusCode', error.code || 500);
 
   if (error.raiseOnEpsagon || !error.code || error.code >= 500) {
     logger.error(error);

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -6,6 +6,20 @@ import DependencyInjection from '../DependencyInjection/DependencyInjection.clas
 import ResponseModel from '../Model/Response.model';
 
 /**
+ * Processes the outcome once we have one
+ *
+ * @param di
+ * @param outcome
+ */
+export const handleSuccess = (di, outcome) => {
+  const logger = di.get(DEFINITIONS.LOGGER);
+
+  logger.metric('lambda.returnCode', outcome.statusCode || 200);
+
+  return outcome;
+};
+
+/**
  * Gracefully handles an error
  * logging in Epsagon and generating
  * a response reflecting the `code`
@@ -16,19 +30,31 @@ import ResponseModel from '../Model/Response.model';
  * This means that logger.error will produce an alert.
  * To avoid not meaningful notifications, most likely
  * coming from tests, we log INFO unless either:
+ *
  * 1. `error.raiseOnEpsagon` is defined & truthy
  * 2. `error.code` is defined and `error.code >= 500`.
  *
  * @param {DependencyInjection} di
  * @param {Error} error
+ * @param {boolean} [throwError=false]
  */
-export const handleError = (di, error) => {
+export const handleError = (di, error, throwError = false) => {
   const logger = di.get(DEFINITIONS.LOGGER);
+
+  logger.metric('lambda.returnCode', error.code || 500);
 
   if (error.raiseOnEpsagon || !error.code || error.code >= 500) {
     logger.error(error);
   } else {
     logger.info(error);
+  }
+
+  if (throwError) {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error(error);
   }
 
   const responseDetails = {
@@ -37,9 +63,7 @@ export const handleError = (di, error) => {
     details: error.details || 'unknown error',
   };
 
-  const response = new ResponseModel(responseDetails.body, responseDetails.code, responseDetails.details);
-
-  return response.generate();
+  return ResponseModel.generate(responseDetails.body, responseDetails.code, responseDetails.details);
 };
 
 /**
@@ -79,20 +103,33 @@ export default (configuration, handler, throwError = false) => {
       });
     }
 
+    let outcome;
+
     try {
-      let outcome = handler.call(instance, di, request, callback);
+      outcome = handler.call(instance, di, request, callback);
 
-      if (outcome instanceof Promise && !throwError) {
-        outcome = outcome.catch((error) => handleError(di, error));
+      if (outcome instanceof Promise) {
+        outcome = outcome
+          .then((value) => handleSuccess(di, value))
+          .catch((error) => {
+            const handled = handleError(di, error, throwError);
+
+            if (throwError) {
+              // AWS Lambda with async handler is looking for a rejection
+              // and not an error object directly
+              // and will treat resolved errors as successful
+              // as it will cast the error to JSON, i.e. `{}`
+              return Promise.reject(handled);
+            }
+
+            return handled;
+          });
       }
-
-      return outcome;
     } catch (error) {
-      if (throwError) {
-        throw error;
-      }
-      return handleError(di, error);
+      outcome = handleError(di, error, throwError);
     }
+
+    return outcome;
   };
 
   // If the Epsagon token is enabled, then wrap the instance in the Epsagon wrapper

--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -14,7 +14,7 @@ import ResponseModel from '../Model/Response.model';
 export const handleSuccess = (di, outcome) => {
   const logger = di.get(DEFINITIONS.LOGGER);
 
-  logger.metric('lambda.returnCode', outcome.statusCode || 200);
+  logger.metric('lambda.statusCode', outcome.statusCode || 200);
 
   return outcome;
 };

--- a/tests/lib/mocks.js
+++ b/tests/lib/mocks.js
@@ -13,8 +13,9 @@ import { DEFINITIONS } from '../../src/Config/Dependencies';
 export const getMockedLogger = (overrides = {}, di = null) => {
   const logger = {
     di,
-    error: jest.fn().mockImplementation(() => overrides.error || null),
-    info: jest.fn().mockImplementation(() => overrides.info || null),
+    error: jest.fn(() => overrides.error || null),
+    info: jest.fn(() => overrides.info || null),
+    metric: jest.fn(() => overrides.metric || null),
   };
 
   logger.getContainer = () => logger.di;

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -141,7 +141,7 @@ describe('Wrapper/LambdaWrapper', () => {
 
         expect(infoStub).not.toHaveBeenCalled();
         expect(errorStub).toHaveBeenCalled();
-        expect(metricStub).nthCalledWith(1, 'lambda.returnCode', 500);
+        expect(metricStub).nthCalledWith(1, 'lambda.statusCode', 500);
       });
 
       [400, 401, 403, 404, 409, 419, 421, 423, 499].forEach((errorCode) => {
@@ -164,7 +164,7 @@ describe('Wrapper/LambdaWrapper', () => {
 
           expect(infoStub).toHaveBeenCalled();
           expect(errorStub).not.toHaveBeenCalled();
-          expect(metricStub).nthCalledWith(1, 'lambda.returnCode', errorCode);
+          expect(metricStub).nthCalledWith(1, 'lambda.statusCode', errorCode);
         });
       });
 
@@ -188,7 +188,7 @@ describe('Wrapper/LambdaWrapper', () => {
 
           expect(infoStub).not.toHaveBeenCalled();
           expect(errorStub).toHaveBeenCalled();
-          expect(metricStub).nthCalledWith(1, 'lambda.returnCode', errorCode);
+          expect(metricStub).nthCalledWith(1, 'lambda.statusCode', errorCode);
         });
       });
 

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -232,7 +232,10 @@ describe('Wrapper/LambdaWrapper', () => {
           const lambda = LambdaWrapper(configuration, handlers.SYNC_THROWING, true);
           const outcome = lambda(getEvent, getContext);
           expect(outcome).toMatchSnapshot();
+
+          // Be absolutely sure we got an Error object or the lambda will not count as failed
           expect(outcome instanceof LambdaTermination).toEqual(true);
+          expect(outcome instanceof Error).toEqual(true);
         });
       });
 
@@ -244,6 +247,8 @@ describe('Wrapper/LambdaWrapper', () => {
 
         it('rejects the promise with throwError === true', async () => {
           const lambda = LambdaWrapper(configuration, handlers.ASYNC_THROWING, true);
+
+          // Be absolutely sure we got a rejection or the lambda will not count as failed
           await expect(lambda(getEvent, getContext)).rejects.toThrowErrorMatchingSnapshot();
         });
       });

--- a/tests/unit/Wrapper/LambdaWrapper.test.js
+++ b/tests/unit/Wrapper/LambdaWrapper.test.js
@@ -1,5 +1,7 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import { DEFINITIONS } from '../../../src/Config/Dependencies';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
+import ResponseModel from '../../../src/Model/Response.model';
 import RequestService, { REQUEST_TYPES } from '../../../src/Service/Request.service';
 import LambdaTermination from '../../../src/Wrapper/LambdaTermination';
 import LambdaWrapper, { handleError } from '../../../src/Wrapper/LambdaWrapper';
@@ -7,6 +9,23 @@ import { getMockedDi } from '../../lib/mocks';
 
 const getContext = require('../../mocks/aws/context.json');
 const getEvent = require('../../mocks/aws/event.json');
+
+const handlers = {
+  SYNC_SUCCESS: () => ResponseModel.generate({ x: 'success' }, 200, 'ok'),
+  SYNC_THROWING: (di) => {
+    jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+    jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
+
+    throw new LambdaTermination('SYNC_THROWING', 403, 'external');
+  },
+  ASYNC_SUCCESS: () => Promise.resolve(ResponseModel.generate({ x: 'success' }, 200, 'ok')),
+  ASYNC_THROWING: (di) => new Promise(() => {
+    jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+    jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
+
+    throw new LambdaTermination('ASYNC_THROWING', 403, 'external');
+  }),
+};
 
 describe('Wrapper/LambdaWrapper', () => {
   let dependencyInjection = {};
@@ -59,6 +78,18 @@ describe('Wrapper/LambdaWrapper', () => {
   });
 
   describe('LambdaWrapper', () => {
+    describe('executes the wrapped function', () => {
+      it('when it is sync', () => {
+        const lambda = LambdaWrapper(configuration, handlers.SYNC_SUCCESS);
+        expect(lambda(getEvent, getContext)).toMatchSnapshot();
+      });
+
+      it('when it is async', async () => {
+        const lambda = LambdaWrapper(configuration, handlers.ASYNC_SUCCESS);
+        await expect(lambda(getEvent, getContext)).resolves.toMatchSnapshot();
+      });
+    });
+
     describe('should inject dependency injection into the function', () => {
       LambdaWrapper(configuration, (di, request) => {
         dependencyInjection = di;
@@ -97,10 +128,12 @@ describe('Wrapper/LambdaWrapper', () => {
       it('Logs.error the error without error code', () => {
         let infoStub;
         let errorStub;
+        let metricStub;
 
         const lambda = LambdaWrapper(configuration, (di) => {
           infoStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'info');
           errorStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+          metricStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
           throw new Error('Undefined error');
         });
 
@@ -108,16 +141,20 @@ describe('Wrapper/LambdaWrapper', () => {
 
         expect(infoStub).not.toHaveBeenCalled();
         expect(errorStub).toHaveBeenCalled();
+        expect(metricStub).nthCalledWith(1, 'lambda.returnCode', 500);
       });
 
       [400, 401, 403, 404, 409, 419, 421, 423, 499].forEach((errorCode) => {
         it(`Logs.info the error with code ${errorCode}`, () => {
           let infoStub;
           let errorStub;
+          let metricStub;
 
           const lambda = LambdaWrapper(configuration, (di) => {
             infoStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'info');
             errorStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+            metricStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
+
             const error = new Error('4xx error');
             error.code = errorCode;
             throw error;
@@ -127,6 +164,7 @@ describe('Wrapper/LambdaWrapper', () => {
 
           expect(infoStub).toHaveBeenCalled();
           expect(errorStub).not.toHaveBeenCalled();
+          expect(metricStub).nthCalledWith(1, 'lambda.returnCode', errorCode);
         });
       });
 
@@ -134,10 +172,13 @@ describe('Wrapper/LambdaWrapper', () => {
         it(`Logs.error the error with code ${errorCode}`, () => {
           let infoStub;
           let errorStub;
+          let metricStub;
 
           const lambda = LambdaWrapper(configuration, (di) => {
             infoStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'info');
             errorStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+            metricStub = jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
+
             const error = new Error('5xx error');
             error.code = errorCode;
             throw error;
@@ -147,12 +188,14 @@ describe('Wrapper/LambdaWrapper', () => {
 
           expect(infoStub).not.toHaveBeenCalled();
           expect(errorStub).toHaveBeenCalled();
+          expect(metricStub).nthCalledWith(1, 'lambda.returnCode', errorCode);
         });
       });
 
       it('Returns 500 exception with a common error', () => {
         const lambda = LambdaWrapper(configuration, (di) => {
           jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+          jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
           throw new Error('Some error');
         });
 
@@ -166,6 +209,7 @@ describe('Wrapper/LambdaWrapper', () => {
       it('Returns a response generated by LambdaTermination', () => {
         const lambda = LambdaWrapper(configuration, (di) => {
           jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
+          jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'metric');
           throw new LambdaTermination('internal', 403, 'external', 'some message');
         });
 
@@ -177,18 +221,30 @@ describe('Wrapper/LambdaWrapper', () => {
         expect(body.message).toEqual('some message');
       });
 
-      it('Catches async errors', () => {
-        const lambda = LambdaWrapper(configuration, (di) => new Promise(() => {
-          jest.spyOn(di.dependencies[DEFINITIONS.LOGGER], 'error');
-          throw new LambdaTermination('internal', 403, 'external');
-        }));
+      describe('catches sync errors', () => {
+        it('returns an error http response with throwError === false', () => {
+          const lambda = LambdaWrapper(configuration, handlers.SYNC_THROWING, false);
+          const outcome = lambda(getEvent, getContext);
+          expect(outcome).toMatchSnapshot();
+        });
 
-        return lambda(getEvent, getContext).then((response) => {
-          const body = JSON.parse(response.body);
+        it('returns a raw error with throwError === true', () => {
+          const lambda = LambdaWrapper(configuration, handlers.SYNC_THROWING, true);
+          const outcome = lambda(getEvent, getContext);
+          expect(outcome).toMatchSnapshot();
+          expect(outcome instanceof LambdaTermination).toEqual(true);
+        });
+      });
 
-          expect(response.statusCode).toEqual(403);
-          expect(body.message).toEqual('unknown error');
-          expect(body.data).toEqual('external');
+      describe('catches async errors', () => {
+        it('resolves an error http response with throwError === false', async () => {
+          const lambda = LambdaWrapper(configuration, handlers.ASYNC_THROWING, false);
+          await expect(lambda(getEvent, getContext)).resolves.toMatchSnapshot();
+        });
+
+        it('rejects the promise with throwError === true', async () => {
+          const lambda = LambdaWrapper(configuration, handlers.ASYNC_THROWING, true);
+          await expect(lambda(getEvent, getContext)).rejects.toThrowErrorMatchingSnapshot();
         });
       });
     });

--- a/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
+++ b/tests/unit/Wrapper/__snapshots__/LambdaWrapper.test.js.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Wrapper/LambdaWrapper LambdaWrapper executes the wrapped function when it is async 1`] = `
+Object {
+  "body": "{\\"data\\":{\\"x\\":\\"success\\"},\\"message\\":\\"ok\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 200,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper LambdaWrapper executes the wrapped function when it is sync 1`] = `
+Object {
+  "body": "{\\"data\\":{\\"x\\":\\"success\\"},\\"message\\":\\"ok\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 200,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper LambdaWrapper should catch exceptions and generate appropriate responses catches async errors rejects the promise with throwError === true 1`] = `"ASYNC_THROWING"`;
+
+exports[`Wrapper/LambdaWrapper LambdaWrapper should catch exceptions and generate appropriate responses catches async errors resolves an error http response with throwError === false 1`] = `
+Object {
+  "body": "{\\"data\\":\\"external\\",\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 403,
+}
+`;
+
+exports[`Wrapper/LambdaWrapper LambdaWrapper should catch exceptions and generate appropriate responses catches sync errors returns a raw error with throwError === true 1`] = `[Error: SYNC_THROWING]`;
+
+exports[`Wrapper/LambdaWrapper LambdaWrapper should catch exceptions and generate appropriate responses catches sync errors returns an error http response with throwError === false 1`] = `
+Object {
+  "body": "{\\"data\\":\\"external\\",\\"message\\":\\"unknown error\\"}",
+  "headers": Object {
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  },
+  "statusCode": 403,
+}
+`;
+
 exports[`Wrapper/LambdaWrapper handleError Generates a response object 1`] = `
 Object {
   "body": "{\\"data\\":{},\\"message\\":\\"unknown error\\"}",


### PR DESCRIPTION
For SQS triggered functions, we throw unhandled exceptions in order to force SQS to requeue the message, so it can be retried according to the related SQS policy.

However, unhandled exceptions break Epsagon's own lambda wrapper, resulting in missing Epsagon traces.

To solve the issue, we can return error objects (i.e. `obj instanceof Error === true`) so that the lambda function completes but still counts as failed.

See:
- [ENG-240]

[ENG-240]: https://comicrelief.atlassian.net/browse/ENG-240