### PR TITLE
feat: Call SQS triggered lambdas directly when using serverless-offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-syntax-flow": "^7.12.1",
     "@babel/plugin-transform-flow-strip-types": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
-    "@comicrelief/eslint-config": "^1.3.0",
+    "@comicrelief/eslint-config": "^1.3.3",
     "@types/jest": "^26.0.20",
     "aws-sdk": ">=2.831.0",
     "babel-eslint": "^10.1.0",

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -283,9 +283,6 @@ export default class SQSService extends DependencyAwareClass {
 
     const parameters = { FunctionName, InvocationType, Payload };
 
-    // Don't await the promise, otherwise
-    // we will have all Lambdas hang until
-    // all queued invocations are completed
     await this.lambda.invoke(parameters).promise();
   }
 

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -1,0 +1,63 @@
+import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
+import SQSService from '../../../src/Service/SQS.service';
+
+const createAsyncMock = (returnValue) => {
+  const mockedValue = returnValue instanceof Error
+    ? Promise.reject(returnValue)
+    : Promise.resolve(returnValue);
+
+  return jest.fn().mockReturnValue({ promise: () => mockedValue });
+};
+
+const TEST_QUEUE = 'TEST_QUEUE';
+
+/**
+ * Generates a SQSService
+ *
+ * @param {*} param0
+ * @param isOffline
+ * @returns {SQSService}
+ */
+const getService = ({ sendMessage = null, invoke = null } = {}, isOffline = false) => {
+  const di = new DependencyInjection({
+    QUEUE_CONSUMERS: { TEST_QUEUE },
+  }, {}, {});
+  const service = new SQSService(di);
+  const sqs = {
+    sendMessage: createAsyncMock(sendMessage),
+  };
+
+  const lambda = {
+    invoke: createAsyncMock(invoke),
+  };
+
+  jest.spyOn(service, 'sqs', 'get').mockReturnValue(sqs);
+  jest.spyOn(service, 'lambda', 'get').mockReturnValue(lambda);
+  jest.spyOn(di, 'isOffline', 'get').mockReturnValue(isOffline);
+
+  return service;
+};
+
+describe('Service/SQS', () => {
+  describe('publish', () => {
+    it('publishes on SQS if container.isOffline === false', async () => {
+      const service = getService({}, false);
+      service.queues.TEST_QUEUE = 'TEST_QUEUE';
+
+      await service.publish(service.queues.TEST_QUEUE, { test: 1 });
+
+      expect(service.sqs.sendMessage).toHaveBeenCalledTimes(1);
+      expect(service.lambda.invoke).toHaveBeenCalledTimes(0);
+    });
+
+    it('sends a lambda request if container.isOffline === true', async () => {
+      const service = getService({}, true);
+      service.queues.TEST_QUEUE = 'TEST_QUEUE';
+
+      await service.publish(service.queues.TEST_QUEUE, { test: 1 });
+
+      expect(service.sqs.sendMessage).toHaveBeenCalledTimes(0);
+      expect(service.lambda.invoke).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,7 +1010,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@comicrelief/eslint-config@^1.3.0":
+"@comicrelief/eslint-config@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@comicrelief/eslint-config/-/eslint-config-1.3.3.tgz#3c0eda207008cc0df1e19149bd9b362dccaf4880"
   integrity sha512-SmQ5GFrwJHK07LZqBUYm368C87Tuezr23dZsP8AgM7ma4I/0sYzBzaZCXl76Dn2wjbIvRkK6yg2ne018gZAbZA==


### PR DESCRIPTION
When using `serverless-offline`, LambdaWrapper performs an HTTP Request trying to pass its content to a message queue instance running on localhost. We can intercept the HTTP Request, but it is problematic to code and to think about.

Serverless Offline allows us to trigger lambdas via the AWS SDK. We can map lambdas to queues via an environment variable and trigger functions directly. This has the added benefit of allowing any number of triggers (i.e. one function that queues 10 messages) and to simplify how we test those functions locally.

See:
- [ENG-245]

[ENG-245]: https://comicrelief.atlassian.net/browse/ENG-245