### PR TITLE
fix: Remove try-catch from SQSService.publish

### DIFF
--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -267,7 +267,6 @@ export default class SQSService extends DependencyAwareClass {
   async publish(queue: string, messageObject: object, messageGroupId = null) {
     const container = this.getContainer();
     const queueUrl = this.queues[queue];
-    const Logger = container.get(DEFINITIONS.LOGGER);
     const Timer = container.get(DEFINITIONS.TIMER);
     const timerId = `sqs-send-message-${UUID()} - Queue: '${queueUrl}'`;
 
@@ -283,14 +282,10 @@ export default class SQSService extends DependencyAwareClass {
       messageParameters.MessageGroupId = messageGroupId !== null ? messageGroupId : UUID();
     }
 
-    try {
-      if (container.isOffline && this.constructor.offlineMode === OFFLINE_MODES.DIRECT) {
-        await this.publishOffline(queue, messageParameters);
-      } else {
-        await this.sqs.sendMessage(messageParameters).promise();
-      }
-    } catch (error) {
-      Logger.error(error);
+    if (container.isOffline && this.constructor.offlineMode === OFFLINE_MODES.DIRECT) {
+      await this.publishOffline(queue, messageParameters);
+    } else {
+      await this.sqs.sendMessage(messageParameters).promise();
     }
 
     return queue;

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -128,5 +128,15 @@ describe('Service/SQS', () => {
         expect(() => getService({}, true)).toThrow();
       });
     });
+
+    it('throws an error if publish fails', async () => {
+      const service = getService({
+        sendMessage: new Error('SQS is down!'),
+      }, false);
+
+      const promise = service.publish(TEST_QUEUE, { test: 1 });
+
+      await expect(promise).rejects.toThrowError('SQS is down!');
+    });
   });
 });


### PR DESCRIPTION
Fixes [ENG-356].

Failure to publish a message should be handled by the caller, as it may be on their critical path.

[ENG-356]: https://comicrelief.atlassian.net/browse/ENG-356