### PR TITLE
feat: Configurable SQS offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Serverless Offline only emulates API Gateway and Lambda, so publishing an SQS me
 
 Offline SQS behaviour can be configured by setting the `LAMBDA_WRAPPER_OFFLINE_SQS_MODE` environment variable. Available modes are:
 
-- `lambda` (the default): send messages to an offline Lambda endpoint
-- `sqs`: send messages to an offline SQS service, such as Localstack
-- `none`: no special handling of SQS offline; messages will be sent to AWS
+- `direct` (the default): invokes the consumer function directly via an offline Lambda endpoint
+- `local`: send messages to an offline SQS endpoint, such as Localstack
+- `aws`: no special handling of SQS offline; messages will be sent to AWS
 
-When you send a message using `SQSService.prototype.publish`, it will check which mode to use and dispatch the message appropriately. These modes take effect only when running offline (as defined by `DependencyInjection.prototype.isOffline`). In a deployed environment, SQS messages will always be sent to AWS SQS.
+Details of each mode are documented in the sections below. When you send a message using `SQSService.prototype.publish`, it will check which mode to use and dispatch the message appropriately. These modes take effect only when running offline (as defined by `DependencyInjection.prototype.isOffline`). In a deployed environment, SQS messages will always be sent to AWS SQS.
 
-### Offline SQS using Lambda
+### Direct Lambda mode
 
-In this mode (which is the default if `LAMBDA_WRAPPER_OFFLINE_SQS_MODE` is not set), a Lambda client will be created and the message will be delivered to the offline Lambda endpoint, effectively running the consumer function _immediately_ as part of the original Lambda invocation. This works very well in the offline environment because invoking a Lambda function will trigger its whole (local) execution tree.
+This is the default mode if `LAMBDA_WRAPPER_OFFLINE_SQS_MODE` is not set. A Lambda client will be created and the message will be delivered to the offline Lambda endpoint, effectively running the consumer function _immediately_ as part of the original Lambda invocation. This works very well in the offline environment because invoking a Lambda function will trigger its whole (local) execution tree.
 
 To take advantage of SQS emulation, you will need to define the following in the implementing service:
 
@@ -77,15 +77,15 @@ The URL is likely to be your localhost URL and the next available port from the 
 
 3. If the triggered lambda incurs an exception, this will be propagated upstream, effectively killing the execution of the calling lambda.
 
-### Using an SQS service
+### Local SQS mode
 
-Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=sqs`. Messages will still be sent to an SQS queue, but using a locally simulated version instead of AWS. This allows you to test your service using a tool like Localstack.
+Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=local`. Messages will still be sent to an SQS queue, but using a locally simulated version instead of AWS. This allows you to test your service using a tool like Localstack.
 
 By default, messages will be sent to a SQS service running on `localhost:4576`. If you need to change the hostname, you can set `process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST`.
 
-### No offline SQS
+### AWS SQS mode
 
-Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=none`. Messages will be sent to the real queue in AWS. This is useful for running end-to-end tests where a message is sent to a queue and eventually appears in an external data store.
+Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=aws`. Messages will be sent to the real queue in AWS. This is useful for running end-to-end tests where a message is sent to a queue and eventually appears in an external data store.
 
 ## Semantic release
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Lambda Wrapper
---------------
+# Lambda Wrapper
 
 [![CircleCI](https://circleci.com/gh/comicrelief/lambda-wrapper.svg?style=svg&circle-token=7db6e0ff0526bd635424f303fd4ffffc7ea05aed)](https://circleci.com/gh/comicrelief/lambda-wrapper)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
@@ -7,7 +6,7 @@ Lambda Wrapper
 
 When writing Serverless endpoints, we have found ourselves replicating a lot of boiler plate code to do basic actions, such as reading request variables or writing to SQS. The aim of this package is to provide a wrapper for our Lambda functions, to provide some level of dependency and configuration injection and to reduce time spent on project setup.
 
-# Installation & usage
+## Installation & usage
 
 Install via npm:
 
@@ -88,6 +87,6 @@ By default, messages will be sent to a SQS service running on `localhost:4576`. 
 
 Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=none`. Messages will be sent to the real queue in AWS. This is useful for running end-to-end tests where a message is sent to a queue and eventually appears in an external data store.
 
-# Semantic release
+## Semantic release
 
 Release management is automated using [semantic-release](https://www.npmjs.com/package/semantic-release).

--- a/src/DependencyInjection/DependencyInjection.class.js
+++ b/src/DependencyInjection/DependencyInjection.class.js
@@ -89,7 +89,7 @@ export default class DependencyInjection {
    * @returns {boolean}
    */
   get isOffline() {
-    const context = this.getContext();
+    const context = this.getContext() || {};
 
     if (!Object.prototype.hasOwnProperty.call(context, 'invokedFunctionArn')) {
       return true;

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -42,12 +42,14 @@ const getService = ({ sendMessage = null, invoke = null } = {}, isOffline = fals
 };
 
 describe('Service/SQS', () => {
+  let envOfflineSqsMode;
+
   beforeAll(() => {
-    process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = undefined;
+    envOfflineSqsMode = process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE;
   });
 
   afterAll(() => {
-    delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE;
+    process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = envOfflineSqsMode;
   });
 
   describe('publish', () => {

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -54,13 +54,12 @@ describe('Service/SQS', () => {
     describe('when container.isOffline === false', () => {
       [
         ['sends to SQS', undefined],
-        ['sends to SQS, even in "lambda" offline mode', 'lambda'],
-        ['sends to SQS, even in "sqs" offline mode', 'sqs'],
-        ['sends to SQS, even in "none" offline mode', 'none'],
+        ['sends to SQS, even in "direct" offline mode', 'direct'],
+        ['sends to SQS, even in "local" offline mode', 'local'],
+        ['sends to SQS, even in "aws" offline mode', 'aws'],
         ['sends to SQS, even in "invalid" offline mode', 'invalid'],
       ].forEach(([description, offlineMode]) => {
         it(description, async () => {
-          process.env.CURRENT_TEST = `SQS/publish/ONLINE/${description}`;
           process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = offlineMode;
           const service = getService({}, false);
 
@@ -77,7 +76,6 @@ describe('Service/SQS', () => {
 
     describe('when container.isOffline === true', () => {
       it('sends a lambda request by default', async () => {
-        process.env.CURRENT_TEST = 'SQS/publish/offline/default';
         delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE;
         const service = getService({}, true);
 
@@ -87,9 +85,8 @@ describe('Service/SQS', () => {
         expect(service.lambda.invoke).toHaveBeenCalledTimes(1);
       });
 
-      it('sends a lambda request in "lambda" mode', async () => {
-        process.env.CURRENT_TEST = 'SQS/publish/offline/lambda';
-        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'lambda';
+      it('sends a lambda request in "direct" mode', async () => {
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'direct';
         const service = getService({}, true);
 
         await service.publish(TEST_QUEUE, { test: 1 });
@@ -98,9 +95,8 @@ describe('Service/SQS', () => {
         expect(service.lambda.invoke).toHaveBeenCalledTimes(1);
       });
 
-      it('sends a local SQS request in "sqs" mode', async () => {
-        process.env.CURRENT_TEST = 'SQS/publish/offline/sqs';
-        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'sqs';
+      it('sends a local SQS request in "local" mode', async () => {
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';
         const service = getService({}, true);
 
         await service.publish(TEST_QUEUE, { test: 1 });
@@ -112,9 +108,8 @@ describe('Service/SQS', () => {
         expect(params.QueueUrl).toContain('localhost');
       });
 
-      it('sends a normal SQS request in "none" mode', async () => {
-        process.env.CURRENT_TEST = 'SQS/publish/offline/none';
-        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'none';
+      it('sends a normal SQS request in "aws" mode', async () => {
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'aws';
         const service = getService({}, true);
 
         await service.publish(TEST_QUEUE, { test: 1 });
@@ -127,7 +122,6 @@ describe('Service/SQS', () => {
       });
 
       it('throws an error for any other mode', async () => {
-        process.env.CURRENT_TEST = 'SQS/publish/offline/invalid';
         process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'invalid';
         expect(() => getService({}, true)).toThrow();
       });

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -1,5 +1,5 @@
+import { DEFINITIONS } from '../../../src/Config/Dependencies';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
-import SQSService from '../../../src/Service/SQS.service';
 
 const createAsyncMock = (returnValue) => {
   const mockedValue = returnValue instanceof Error
@@ -20,9 +20,13 @@ const TEST_QUEUE = 'TEST_QUEUE';
  */
 const getService = ({ sendMessage = null, invoke = null } = {}, isOffline = false) => {
   const di = new DependencyInjection({
+    QUEUES: { TEST_QUEUE },
     QUEUE_CONSUMERS: { TEST_QUEUE },
-  }, {}, {});
-  const service = new SQSService(di);
+  }, {}, {
+    invokedFunctionArn: isOffline ? 'offline' : 'arn:aws:lambda:eu-west-1:0000:test',
+  });
+
+  const service = di.get(DEFINITIONS.SQS);
   const sqs = {
     sendMessage: createAsyncMock(sendMessage),
   };
@@ -33,31 +37,100 @@ const getService = ({ sendMessage = null, invoke = null } = {}, isOffline = fals
 
   jest.spyOn(service, 'sqs', 'get').mockReturnValue(sqs);
   jest.spyOn(service, 'lambda', 'get').mockReturnValue(lambda);
-  jest.spyOn(di, 'isOffline', 'get').mockReturnValue(isOffline);
 
   return service;
 };
 
 describe('Service/SQS', () => {
+  beforeAll(() => {
+    process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = undefined;
+  });
+
+  afterAll(() => {
+    delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE;
+  });
+
   describe('publish', () => {
-    it('publishes on SQS if container.isOffline === false', async () => {
-      const service = getService({}, false);
-      service.queues.TEST_QUEUE = 'TEST_QUEUE';
+    describe('when container.isOffline === false', () => {
+      [
+        ['sends to SQS', undefined],
+        ['sends to SQS, even in "lambda" offline mode', 'lambda'],
+        ['sends to SQS, even in "sqs" offline mode', 'sqs'],
+        ['sends to SQS, even in "none" offline mode', 'none'],
+        ['sends to SQS, even in "invalid" offline mode', 'invalid'],
+      ].forEach(([description, offlineMode]) => {
+        it(description, async () => {
+          process.env.CURRENT_TEST = `SQS/publish/ONLINE/${description}`;
+          process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = offlineMode;
+          const service = getService({}, false);
 
-      await service.publish(service.queues.TEST_QUEUE, { test: 1 });
+          await service.publish(TEST_QUEUE, { test: 1 });
 
-      expect(service.sqs.sendMessage).toHaveBeenCalledTimes(1);
-      expect(service.lambda.invoke).toHaveBeenCalledTimes(0);
+          expect(service.sqs.sendMessage).toHaveBeenCalledTimes(1);
+          expect(service.lambda.invoke).toHaveBeenCalledTimes(0);
+
+          const params = service.sqs.sendMessage.mock.calls[0][0];
+          expect(params.QueueUrl).not.toContain('localhost');
+        });
+      });
     });
 
-    it('sends a lambda request if container.isOffline === true', async () => {
-      const service = getService({}, true);
-      service.queues.TEST_QUEUE = 'TEST_QUEUE';
+    describe('when container.isOffline === true', () => {
+      it('sends a lambda request by default', async () => {
+        process.env.CURRENT_TEST = 'SQS/publish/offline/default';
+        delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE;
+        const service = getService({}, true);
 
-      await service.publish(service.queues.TEST_QUEUE, { test: 1 });
+        await service.publish(TEST_QUEUE, { test: 1 });
 
-      expect(service.sqs.sendMessage).toHaveBeenCalledTimes(0);
-      expect(service.lambda.invoke).toHaveBeenCalledTimes(1);
+        expect(service.sqs.sendMessage).toHaveBeenCalledTimes(0);
+        expect(service.lambda.invoke).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends a lambda request in "lambda" mode', async () => {
+        process.env.CURRENT_TEST = 'SQS/publish/offline/lambda';
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'lambda';
+        const service = getService({}, true);
+
+        await service.publish(TEST_QUEUE, { test: 1 });
+
+        expect(service.sqs.sendMessage).toHaveBeenCalledTimes(0);
+        expect(service.lambda.invoke).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends a local SQS request in "sqs" mode', async () => {
+        process.env.CURRENT_TEST = 'SQS/publish/offline/sqs';
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'sqs';
+        const service = getService({}, true);
+
+        await service.publish(TEST_QUEUE, { test: 1 });
+
+        expect(service.sqs.sendMessage).toHaveBeenCalledTimes(1);
+        expect(service.lambda.invoke).toHaveBeenCalledTimes(0);
+
+        const params = service.sqs.sendMessage.mock.calls[0][0];
+        expect(params.QueueUrl).toContain('localhost');
+      });
+
+      it('sends a normal SQS request in "none" mode', async () => {
+        process.env.CURRENT_TEST = 'SQS/publish/offline/none';
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'none';
+        const service = getService({}, true);
+
+        await service.publish(TEST_QUEUE, { test: 1 });
+
+        expect(service.sqs.sendMessage).toHaveBeenCalledTimes(1);
+        expect(service.lambda.invoke).toHaveBeenCalledTimes(0);
+
+        const params = service.sqs.sendMessage.mock.calls[0][0];
+        expect(params.QueueUrl).not.toContain('localhost');
+      });
+
+      it('throws an error for any other mode', async () => {
+        process.env.CURRENT_TEST = 'SQS/publish/offline/invalid';
+        process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'invalid';
+        expect(() => getService({}, true)).toThrow();
+      });
     });
   });
 });


### PR DESCRIPTION
This PR makes offline SQS behaviour configurable using the `LAMBDA_WRAPPER_OFFLINE_SQS_MODE` environment variable.

This will allow end-to-end tests that really do need to publish to SQS to run in serverless-offline, and also provides a way to recreate the old lambda-wrapper behaviour of sending to Localstack.

Discussion around the names of options is welcome – the current names may not be the clearest! In particular, `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=none` could be interpretted as "there will be no SQS messages sent when offline" rather than the intended "there is no special redirection of SQS messages when offline".