### PR TITLE
fix: Default SQS.publish behaviour to not throw exceptions

### DIFF
--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -45,13 +45,13 @@ export const SQS_PUBLISH_FAILURE_MODES = {
    * for LambdaWrapper 1.8.0 and below
    * and for LambdaWrapper 1.8.2 and above
    */
-  CATCH: 'CATCH',
+  CATCH: 'catch',
 
   /**
    * Throws the exception so that the caller
    * can handle it directly.
    */
-  THROW: 'THROW',
+  THROW: 'throw',
 };
 
 /**
@@ -313,9 +313,12 @@ export default class SQSService extends DependencyAwareClass {
         await this.sqs.sendMessage(messageParameters).promise();
       }
     } catch (error) {
+      if (!Object.values(SQS_PUBLISH_FAILURE_MODES).includes(failureMode)) {
+        throw new Error(`bad value for failureMode: ${failureMode}`);
+      }
+
       switch (failureMode) {
       case SQS_PUBLISH_FAILURE_MODES.CATCH:
-      case '':
         container.get(DEFINITIONS.LOGGER).error(error);
 
         return null;

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -289,6 +289,10 @@ export default class SQSService extends DependencyAwareClass {
    * @returns {Promise<any>}
    */
   async publish(queue: string, messageObject: object, messageGroupId = null, failureMode = SQS_PUBLISH_FAILURE_MODES.CATCH) {
+    if (!Object.values(SQS_PUBLISH_FAILURE_MODES).includes(failureMode)) {
+      throw new Error(`Invalid value for 'failureMode': ${failureMode}`);
+    }
+
     const container = this.getContainer();
     const queueUrl = this.queues[queue];
     const Timer = container.get(DEFINITIONS.TIMER);
@@ -313,10 +317,6 @@ export default class SQSService extends DependencyAwareClass {
         await this.sqs.sendMessage(messageParameters).promise();
       }
     } catch (error) {
-      if (!Object.values(SQS_PUBLISH_FAILURE_MODES).includes(failureMode)) {
-        throw new Error(`bad value for failureMode: ${failureMode}`);
-      }
-
       switch (failureMode) {
       case SQS_PUBLISH_FAILURE_MODES.CATCH:
         container.get(DEFINITIONS.LOGGER).error(error);

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -283,7 +283,9 @@ export default class SQSService extends DependencyAwareClass {
    * @param queue          string
    * @param messageObject  object
    * @param messageGroupId string
-   * @param failureMode
+   * @param {'catch' | 'throw'} failureMode Choose how failures are handled:
+   *   - `catch`: errors will be caught and logged. This is the default.
+   *   - `throw`: errors will be thrown, causing promise to reject.
    * @returns {Promise<any>}
    */
   async publish(queue: string, messageObject: object, messageGroupId = null, failureMode = SQS_PUBLISH_FAILURE_MODES.CATCH) {
@@ -312,15 +314,15 @@ export default class SQSService extends DependencyAwareClass {
       }
     } catch (error) {
       switch (failureMode) {
-      case SQS_PUBLISH_FAILURE_MODES.THROW:
-        throw error;
-
-      case '':
       case SQS_PUBLISH_FAILURE_MODES.CATCH:
-      default:
+      case '':
         container.get(DEFINITIONS.LOGGER).error(error);
 
         return null;
+
+      case SQS_PUBLISH_FAILURE_MODES.THROW:
+      default:
+        throw error;
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export { default as BaseConfigService } from './Service/BaseConfig.service';
 export { default as HTTPService, COMICRELIEF_TEST_METADATA_HEADER } from './Service/HTTP.service';
 export { default as LoggerService } from './Service/Logger.service';
 export { default as RequestService } from './Service/Request.service';
-export { default as SQSService } from './Service/SQS.service';
+export { default as SQSService, OFFLINE_MODES, SQS_PUBLISH_FAILURE_MODES } from './Service/SQS.service';
 
 // Wrapper
 export { default as LambdaTermination } from './Wrapper/LambdaTermination';

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export { default as BaseConfigService } from './Service/BaseConfig.service';
 export { default as HTTPService, COMICRELIEF_TEST_METADATA_HEADER } from './Service/HTTP.service';
 export { default as LoggerService } from './Service/Logger.service';
 export { default as RequestService } from './Service/Request.service';
-export { default as SQSService, OFFLINE_MODES, SQS_PUBLISH_FAILURE_MODES } from './Service/SQS.service';
+export { default as SQSService, SQS_OFFLINE_MODES, SQS_PUBLISH_FAILURE_MODES } from './Service/SQS.service';
 
 // Wrapper
 export { default as LambdaTermination } from './Wrapper/LambdaTermination';

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -175,13 +175,11 @@ describe('Service/SQS', () => {
       'another-value',
     ].forEach((invalidValue) => {
       it(`throws an error with the invalid value: ${invalidValue}`, async () => {
-        const service = getService({
-          sendMessage: new Error('SQS is down!'),
-        }, false);
+        const service = getService();
 
         const promise = service.publish(TEST_QUEUE, { test: 1 }, null, invalidValue);
 
-        await expect(promise).rejects.toMatchSnapshot();
+        await expect(promise).rejects.toThrowErrorMatchingSnapshot();
       });
     });
   });

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 import { DEFINITIONS } from '../../../src/Config/Dependencies';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import { SQS_PUBLISH_FAILURE_MODES } from '../../../src/Service/SQS.service';
@@ -138,34 +139,49 @@ describe('Service/SQS', () => {
       });
     });
 
-    [
-      SQS_PUBLISH_FAILURE_MODES.CATCH,
-      '',
-      undefined,
-    ].forEach((catchCase) => {
-      it(`catches the error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${catchCase}`, async () => {
-        const service = getService({
-          sendMessage: new Error('SQS is down!'),
-        }, false);
+    it(`catches the error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${SQS_PUBLISH_FAILURE_MODES.CATCH}`, async () => {
+      const service = getService({
+        sendMessage: new Error('SQS is down!'),
+      }, false);
 
-        const promise = service.publish(TEST_QUEUE, { test: 1 }, null, catchCase);
+      const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.CATCH);
 
-        await expect(promise).resolves.toEqual(null);
-      });
+      await expect(promise).resolves.toEqual(null);
+    });
+
+    it('catches the error if publish fails with SQS_PUBLISH_FAILURE_MODES === undefined', async () => {
+      const service = getService({
+        sendMessage: new Error('SQS is down!'),
+      }, false);
+
+      const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.CATCH);
+
+      await expect(promise).resolves.toEqual(null);
+    });
+
+    it(`throws an error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${SQS_PUBLISH_FAILURE_MODES.THROW}`, async () => {
+      const service = getService({
+        sendMessage: new Error('SQS is down!'),
+      }, false);
+
+      const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.THROW);
+
+      await expect(promise).rejects.toThrowError('SQS is down!');
     });
 
     [
-      SQS_PUBLISH_FAILURE_MODES.THROW,
+      '',
+      null,
       'another-value',
-    ].forEach((throwCase) => {
-      it(`throws an error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${throwCase}`, async () => {
+    ].forEach((invalidValue) => {
+      it(`throws an error with the invalid value: ${invalidValue}`, async () => {
         const service = getService({
           sendMessage: new Error('SQS is down!'),
         }, false);
 
-        const promise = service.publish(TEST_QUEUE, { test: 1 }, null, throwCase);
+        const promise = service.publish(TEST_QUEUE, { test: 1 }, null, invalidValue);
 
-        await expect(promise).rejects.toThrowError('SQS is down!');
+        await expect(promise).rejects.toMatchSnapshot();
       });
     });
   });

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-identical-functions */
 import { DEFINITIONS } from '../../../src/Config/Dependencies';
 import DependencyInjection from '../../../src/DependencyInjection/DependencyInjection.class';
 import { SQS_PUBLISH_FAILURE_MODES } from '../../../src/Service/SQS.service';

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -139,7 +139,7 @@ describe('Service/SQS', () => {
       });
     });
 
-    it(`catches the error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${SQS_PUBLISH_FAILURE_MODES.CATCH}`, async () => {
+    it(`catches the error if publish fails with failureMode === ${SQS_PUBLISH_FAILURE_MODES.CATCH}`, async () => {
       const service = getService({
         sendMessage: new Error('SQS is down!'),
       }, false);
@@ -149,17 +149,17 @@ describe('Service/SQS', () => {
       await expect(promise).resolves.toEqual(null);
     });
 
-    it('catches the error if publish fails with SQS_PUBLISH_FAILURE_MODES === undefined', async () => {
+    it('catches the error if publish fails with failureMode === undefined', async () => {
       const service = getService({
         sendMessage: new Error('SQS is down!'),
       }, false);
 
-      const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.CATCH);
+      const promise = service.publish(TEST_QUEUE, { test: 1 }, null);
 
       await expect(promise).resolves.toEqual(null);
     });
 
-    it(`throws an error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${SQS_PUBLISH_FAILURE_MODES.THROW}`, async () => {
+    it(`throws an error if publish fails with failureMode === ${SQS_PUBLISH_FAILURE_MODES.THROW}`, async () => {
       const service = getService({
         sendMessage: new Error('SQS is down!'),
       }, false);

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -142,7 +142,6 @@ describe('Service/SQS', () => {
       SQS_PUBLISH_FAILURE_MODES.CATCH,
       '',
       undefined,
-      'another-value',
     ].forEach((catchCase) => {
       it(`catches the error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${catchCase}`, async () => {
         const service = getService({
@@ -157,6 +156,7 @@ describe('Service/SQS', () => {
 
     [
       SQS_PUBLISH_FAILURE_MODES.THROW,
+      'another-value',
     ].forEach((throwCase) => {
       it(`throws an error if publish fails with SQS_PUBLISH_FAILURE_MODES === ${throwCase}`, async () => {
         const service = getService({

--- a/tests/unit/Service/__snapshots__/SQS.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/SQS.service.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Service/SQS publish throws an error with the invalid value:  1`] = `[Error: bad value for failureMode: ]`;
+exports[`Service/SQS publish throws an error with the invalid value:  1`] = `"Invalid value for 'failureMode': "`;
 
-exports[`Service/SQS publish throws an error with the invalid value: another-value 1`] = `[Error: bad value for failureMode: another-value]`;
+exports[`Service/SQS publish throws an error with the invalid value: another-value 1`] = `"Invalid value for 'failureMode': another-value"`;
 
-exports[`Service/SQS publish throws an error with the invalid value: null 1`] = `[Error: bad value for failureMode: null]`;
+exports[`Service/SQS publish throws an error with the invalid value: null 1`] = `"Invalid value for 'failureMode': null"`;

--- a/tests/unit/Service/__snapshots__/SQS.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/SQS.service.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Service/SQS publish throws an error with the invalid value:  1`] = `[Error: bad value for failureMode: ]`;
+
+exports[`Service/SQS publish throws an error with the invalid value: another-value 1`] = `[Error: bad value for failureMode: another-value]`;
+
+exports[`Service/SQS publish throws an error with the invalid value: null 1`] = `[Error: bad value for failureMode: null]`;


### PR DESCRIPTION
Instead of throwing, we should let the default behaviour for LambdaWrapper to catch exceptions.

Services needing to throw, should pass a `failureMode` flag

See:
- [ENG-375]

[ENG-375]: https://comicrelief.atlassian.net/browse/ENG-375