### PR TITLE
fix: Don't expect all lambdas to have a return value

### DIFF
--- a/src/Wrapper/LambdaWrapper.js
+++ b/src/Wrapper/LambdaWrapper.js
@@ -14,7 +14,8 @@ import ResponseModel from '../Model/Response.model';
 export const handleSuccess = (di, outcome) => {
   const logger = di.get(DEFINITIONS.LOGGER);
 
-  logger.metric('lambda.statusCode', outcome.statusCode || 200);
+  // Outcome may be undefined as not all lambdas have a return value.
+  logger.metric('lambda.statusCode', (outcome && outcome.statusCode) || 200);
 
   return outcome;
 };


### PR DESCRIPTION
The contact store was updated yesterday; it has scheduled tasks that don't return a value so we are getting `Cannot read property 'statusCode' of undefined` errors.