### PR TITLE
feat: Get SQS account ID from env when offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ By default, messages will be sent to a SQS service running on `localhost:4576`. 
 
 ### AWS SQS mode
 
-Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=aws`. Messages will be sent to the real queue in AWS. This is useful for running end-to-end tests where a message is sent to a queue and eventually appears in an external data store.
+Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=aws`. Messages will be sent to the real queue in AWS. This mode is useful when a queue is consumed by an external service, rather than another function in the service under test.
+
+In order for queue URLs to be correctly constructed, you must either:
+
+- set `AWS_ACCOUNT_ID` to the account ID that hosts your queue; or
+- invoke offline functions via the Lambda API, passing a context that contains a realistic `invokedFunctionArn` including the account ID.
 
 ## Semantic release
 

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -1,5 +1,5 @@
 /* @flow */
-import Alai from 'alai';
+import alai from 'alai';
 import each from 'async/each';
 import AWS from 'aws-sdk';
 import { v4 as UUID } from 'uuid';
@@ -65,14 +65,6 @@ export default class SQSService extends DependencyAwareClass {
    */
   constructor(di: DependencyInjection) {
     super(di);
-    const container = this.getContainer();
-    const context = container.getContext();
-    const queues = container.getConfiguration('QUEUES');
-
-    this.queues = {};
-
-    this.$lambda = null;
-    this.$sqs = null;
 
     const {
       LAMBDA_WRAPPER_OFFLINE_SQS_HOST: offlineHost = 'localhost',
@@ -81,7 +73,15 @@ export default class SQSService extends DependencyAwareClass {
       REGION,
     } = process.env;
 
-    const accountId = Alai.parse(context) || AWS_ACCOUNT_ID;
+    const container = this.getContainer();
+    const context = container.getContext();
+    const queues = container.getConfiguration('QUEUES');
+    const accountId = alai.parse(context) || AWS_ACCOUNT_ID;
+
+    this.queues = {};
+
+    this.$lambda = null;
+    this.$sqs = null;
 
     if (container.isOffline && !Object.values(SQS_OFFLINE_MODES).includes(offlineMode)) {
       throw new Error(`Invalid LAMBDA_WRAPPER_OFFLINE_SQS_MODE: ${offlineMode}\n`

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -77,8 +77,11 @@ export default class SQSService extends DependencyAwareClass {
     const {
       LAMBDA_WRAPPER_OFFLINE_SQS_HOST: offlineHost = 'localhost',
       LAMBDA_WRAPPER_OFFLINE_SQS_MODE: offlineMode = SQS_OFFLINE_MODES.DIRECT,
+      AWS_ACCOUNT_ID,
       REGION,
     } = process.env;
+
+    const accountId = Alai.parse(context) || AWS_ACCOUNT_ID;
 
     if (container.isOffline && !Object.values(SQS_OFFLINE_MODES).includes(offlineMode)) {
       throw new Error(`Invalid LAMBDA_WRAPPER_OFFLINE_SQS_MODE: ${offlineMode}\n`
@@ -93,7 +96,7 @@ export default class SQSService extends DependencyAwareClass {
           this.queues[queueDefinition] = `http://${offlineHost}:4576/queue/${queues[queueDefinition]}`;
         } else {
           // default AWS queue URL
-          this.queues[queueDefinition] = `https://sqs.${REGION}.amazonaws.com/${Alai.parse(context)}/${queues[queueDefinition]}`;
+          this.queues[queueDefinition] = `https://sqs.${REGION}.amazonaws.com/${accountId}/${queues[queueDefinition]}`;
         }
       });
     }

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -76,7 +76,7 @@ export default class SQSService extends DependencyAwareClass {
     const container = this.getContainer();
     const context = container.getContext();
     const queues = container.getConfiguration('QUEUES');
-    const accountId = alai.parse(context) || AWS_ACCOUNT_ID;
+    const accountId = (context && context.invokedFunctionArn && alai.parse(context)) || AWS_ACCOUNT_ID;
 
     this.queues = {};
 

--- a/tests/unit/DependencyInjection/DependencyInjection.class.test.js
+++ b/tests/unit/DependencyInjection/DependencyInjection.class.test.js
@@ -71,7 +71,7 @@ describe('DependencyInjection/DependencyInjectionClass', () => {
         expect(di.isOffline).toEqual(true);
       });
 
-      it('When process.env.USES_SERVERLESS_OFFLINE is defined', () => {
+      it('When process.env.USE_SERVERLESS_OFFLINE is defined', () => {
         process.env.USE_SERVERLESS_OFFLINE = 'true';
         const di = new DependencyInjection({}, getEvent, { invokedFunctionArn: 'my-function' });
         expect(di.isOffline).toEqual(true);

--- a/tests/unit/Service/BaseConfig.service.test.js
+++ b/tests/unit/Service/BaseConfig.service.test.js
@@ -18,7 +18,7 @@ const createAsyncMock = (returnValue) => {
  * @returns {BaseConfigService}
  */
 const getService = ({ getObject = null, putObject = null, deleteObject = null } = {}) => {
-  const di = new DependencyInjection({});
+  const di = new DependencyInjection({}, {}, {});
   const service = new BaseConfigService(di);
   const client = {
     getObject: createAsyncMock(getObject),
@@ -261,7 +261,7 @@ describe('Service/BaseConfigService', () => {
     });
 
     it('Returns an s3 instance', () => {
-      const di = new DependencyInjection({});
+      const di = new DependencyInjection({}, {}, {});
       const service = new BaseConfigService(di);
 
       expect(service.client instanceof S3).toEqual(true);

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -138,47 +138,49 @@ describe('Service/SQS', () => {
       });
     });
 
-    it(`catches the error if publish fails with failureMode === ${SQS_PUBLISH_FAILURE_MODES.CATCH}`, async () => {
-      const service = getService({
-        sendMessage: new Error('SQS is down!'),
-      }, false);
+    describe('failure modes', () => {
+      it(`catches the error if publish fails with failureMode === ${SQS_PUBLISH_FAILURE_MODES.CATCH}`, async () => {
+        const service = getService({
+          sendMessage: new Error('SQS is down!'),
+        }, false);
 
-      const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.CATCH);
+        const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.CATCH);
 
-      await expect(promise).resolves.toEqual(null);
-    });
+        await expect(promise).resolves.toEqual(null);
+      });
 
-    it('catches the error if publish fails with failureMode === undefined', async () => {
-      const service = getService({
-        sendMessage: new Error('SQS is down!'),
-      }, false);
+      it('catches the error if publish fails with failureMode omitted', async () => {
+        const service = getService({
+          sendMessage: new Error('SQS is down!'),
+        }, false);
 
-      const promise = service.publish(TEST_QUEUE, { test: 1 }, null);
+        const promise = service.publish(TEST_QUEUE, { test: 1 }, null);
 
-      await expect(promise).resolves.toEqual(null);
-    });
+        await expect(promise).resolves.toEqual(null);
+      });
 
-    it(`throws an error if publish fails with failureMode === ${SQS_PUBLISH_FAILURE_MODES.THROW}`, async () => {
-      const service = getService({
-        sendMessage: new Error('SQS is down!'),
-      }, false);
+      it(`throws an error if publish fails with failureMode === ${SQS_PUBLISH_FAILURE_MODES.THROW}`, async () => {
+        const service = getService({
+          sendMessage: new Error('SQS is down!'),
+        }, false);
 
-      const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.THROW);
+        const promise = service.publish(TEST_QUEUE, { test: 1 }, null, SQS_PUBLISH_FAILURE_MODES.THROW);
 
-      await expect(promise).rejects.toThrowError('SQS is down!');
-    });
+        await expect(promise).rejects.toThrowError('SQS is down!');
+      });
 
-    [
-      '',
-      null,
-      'another-value',
-    ].forEach((invalidValue) => {
-      it(`throws an error with the invalid value: ${invalidValue}`, async () => {
-        const service = getService();
+      [
+        '',
+        null,
+        'another-value',
+      ].forEach((invalidValue) => {
+        it(`throws an error with the invalid value: ${invalidValue}`, async () => {
+          const service = getService();
 
-        const promise = service.publish(TEST_QUEUE, { test: 1 }, null, invalidValue);
+          const promise = service.publish(TEST_QUEUE, { test: 1 }, null, invalidValue);
 
-        await expect(promise).rejects.toThrowErrorMatchingSnapshot();
+          await expect(promise).rejects.toThrowErrorMatchingSnapshot();
+        });
       });
     });
   });

--- a/tests/unit/Service/__snapshots__/SQS.service.test.js.snap
+++ b/tests/unit/Service/__snapshots__/SQS.service.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Service/SQS publish throws an error with the invalid value:  1`] = `"Invalid value for 'failureMode': "`;
+exports[`Service/SQS publish failure modes throws an error with the invalid value:  1`] = `"Invalid value for 'failureMode': "`;
 
-exports[`Service/SQS publish throws an error with the invalid value: another-value 1`] = `"Invalid value for 'failureMode': another-value"`;
+exports[`Service/SQS publish failure modes throws an error with the invalid value: another-value 1`] = `"Invalid value for 'failureMode': another-value"`;
 
-exports[`Service/SQS publish throws an error with the invalid value: null 1`] = `"Invalid value for 'failureMode': null"`;
+exports[`Service/SQS publish failure modes throws an error with the invalid value: null 1`] = `"Invalid value for 'failureMode': null"`;


### PR DESCRIPTION
Currently, the SQS account ID (which is required to build a queue URL) is extracted from function ARN in the Lambda context. When running in `serverless-offline`, the context is faked and the account ID comes out as `undefined`, resulting in invalid queue URLs.

This issue happens only when using `serverless-offline` and the `aws` offline SQS mode.

To solve it, `SQSService` will now fall back to getting the account ID from an environment variable `AWS_ACCOUNT_ID`.

Jira: [ENG-1055]