### PR TITLE
fix: Logger.label was not labelling traces

### DIFF
--- a/src/Service/Logger.service.js
+++ b/src/Service/Logger.service.js
@@ -235,7 +235,7 @@ export default class LoggerService extends DependencyAwareClass {
       && typeof process.env.EPSAGON_SERVICE_NAME === 'string'
       && process.env.EPSAGON_SERVICE_NAME !== 'undefined'
     ) {
-      Epsagon.label(descriptor);
+      Epsagon.label(descriptor, true);
     }
 
     if (silent === false) {


### PR DESCRIPTION
As reported by Tom, Epsagon's `label()` function expects two arugments, and fails silently if only one is given.

See their docs: https://docs.epsagon.com/docs/nodejs#tagging-traces

Jira: [ENG-419]

[ENG-419]: https://comicrelief.atlassian.net/browse/ENG-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ