### PR TITLE
feat: Allow SQS port number to be passed as environmental configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The URL is likely to be your localhost URL and the next available port from the 
 Use this mode by setting `LAMBDA_WRAPPER_OFFLINE_SQS_MODE=local`. Messages will still be sent to an SQS queue, but using a locally simulated version instead of AWS. This allows you to test your service using a tool like Localstack.
 
 By default, messages will be sent to a SQS service running on `localhost:4576`. If you need to change the hostname, you can set `process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST`.
+Also, if you need to change the port, you can set `process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT`.
 
 ### AWS SQS mode
 

--- a/src/Service/SQS.service.js
+++ b/src/Service/SQS.service.js
@@ -68,6 +68,7 @@ export default class SQSService extends DependencyAwareClass {
 
     const {
       LAMBDA_WRAPPER_OFFLINE_SQS_HOST: offlineHost = 'localhost',
+      LAMBDA_WRAPPER_OFFLINE_SQS_PORT: offlinePort = '4576',
       LAMBDA_WRAPPER_OFFLINE_SQS_MODE: offlineMode = SQS_OFFLINE_MODES.DIRECT,
       AWS_ACCOUNT_ID,
       REGION,
@@ -93,7 +94,7 @@ export default class SQSService extends DependencyAwareClass {
       Object.keys(queues).forEach((queueDefinition) => {
         if (container.isOffline && offlineMode === SQS_OFFLINE_MODES.LOCAL) {
           // custom URL when using an offline SQS service such as Localstack
-          this.queues[queueDefinition] = `http://${offlineHost}:4576/queue/${queues[queueDefinition]}`;
+          this.queues[queueDefinition] = `http://${offlineHost}:${offlinePort}/queue/${queues[queueDefinition]}`;
         } else {
           // default AWS queue URL
           this.queues[queueDefinition] = `https://sqs.${REGION}.amazonaws.com/${accountId}/${queues[queueDefinition]}`;

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -49,17 +49,23 @@ const getService = ({ sendMessage = null, invoke = null } = {}, isOffline = fals
 describe('Service/SQS', () => {
   let envAccountId;
   let envOfflineSqsMode;
+  let envOfflineSqsHost;
+  let envOfflineSqsPort;
   let envRegion;
 
   beforeAll(() => {
     envAccountId = process.env.AWS_ACCOUNT_ID;
     envOfflineSqsMode = process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE;
+    envOfflineSqsHost = process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST;
+    envOfflineSqsPort = process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT;
     envRegion = process.env.REGION;
   });
 
   afterAll(() => {
     process.env.AWS_ACCOUNT_ID = envAccountId;
     process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = envOfflineSqsMode;
+    process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST = envOfflineSqsHost;
+    process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT = envOfflineSqsPort;
     process.env.REGION = envRegion;
   });
 
@@ -113,6 +119,8 @@ describe('Service/SQS', () => {
       });
 
       it('sends a local SQS request in "local" mode', async () => {
+        delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST;
+        delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT;
         process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';
         const service = getService({}, true);
 
@@ -162,6 +170,8 @@ describe('Service/SQS', () => {
 
       describe('when container.isOffline === true', () => {
         it('should use a LocalStack URL in "local" mode', async () => {
+          delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST;
+          delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT;
           process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';
           const service = getService({}, true);
 
@@ -172,6 +182,7 @@ describe('Service/SQS', () => {
         });
 
         it('should use a custom host in "local" mode', async () => {
+          delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT;
           process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';
           process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST = 'custom-host';
           const service = getService({}, true);

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -182,7 +182,6 @@ describe('Service/SQS', () => {
           expect(params.QueueUrl).toEqual('http://custom-host:4576/queue/QueueName');
         });
 
-
         it('should use a custom port in "local" mode', async () => {
           delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST;
           process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';

--- a/tests/unit/Service/SQS.service.test.js
+++ b/tests/unit/Service/SQS.service.test.js
@@ -123,6 +123,7 @@ describe('Service/SQS', () => {
 
         const params = service.sqs.sendMessage.mock.calls[0][0];
         expect(params.QueueUrl).toContain('localhost');
+        expect(params.QueueUrl).toContain('4576');
       });
 
       it('sends a normal SQS request in "aws" mode', async () => {
@@ -136,6 +137,7 @@ describe('Service/SQS', () => {
 
         const params = service.sqs.sendMessage.mock.calls[0][0];
         expect(params.QueueUrl).not.toContain('localhost');
+        expect(params.QueueUrl).not.toContain('4576');
       });
 
       it('throws an error for any other mode', async () => {
@@ -167,6 +169,30 @@ describe('Service/SQS', () => {
 
           const params = service.sqs.sendMessage.mock.calls[0][0];
           expect(params.QueueUrl).toEqual('http://localhost:4576/queue/QueueName');
+        });
+
+        it('should use a custom host in "local" mode', async () => {
+          process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';
+          process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST = 'custom-host';
+          const service = getService({}, true);
+
+          await service.publish(TEST_QUEUE, { test: 1 });
+
+          const params = service.sqs.sendMessage.mock.calls[0][0];
+          expect(params.QueueUrl).toEqual('http://custom-host:4576/queue/QueueName');
+        });
+
+
+        it('should use a custom port in "local" mode', async () => {
+          delete process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST;
+          process.env.LAMBDA_WRAPPER_OFFLINE_SQS_MODE = 'local';
+          process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT = '4566';
+          const service = getService({}, true);
+
+          await service.publish(TEST_QUEUE, { test: 1 });
+
+          const params = service.sqs.sendMessage.mock.calls[0][0];
+          expect(params.QueueUrl).toEqual('http://localhost:4566/queue/QueueName');
         });
 
         it('should use a correctly formed AWS queue URL in "aws" mode', async () => {


### PR DESCRIPTION
Please refer to **#659 SQS Port as Env. Configuration** for more details.