### PR TITLE
ci: Update publishing token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,5 +73,5 @@ jobs:
       - name: Publish via Semantic Release
         run: yarn semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PUBLISHING_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,6 @@ jobs:
 
       - name: Build and publish release.
         run: yarn install
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish via Semantic Release
         run: yarn semantic-release


### PR DESCRIPTION
As you can see from the [latest attempt to publish](https://github.com/comicrelief/lambda-wrapper/runs/7948453941?check_suite_focus=true), this repo is still using the old token!