### PR TITLE
ci: Run publish job on `beta` branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: unit-test
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently config allows publishing from `master` only.