### PR TITLE
feat: Export `RESPONSE_HEADERS` and fix its type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export { default as LambdaWrapper, WrapOptions } from './core/LambdaWrapper';
 
 export {
   default as ResponseModel,
+  RESPONSE_HEADERS,
 } from './models/ResponseModel';
 export {
   default as SQSMessageModel,

--- a/src/models/ResponseModel.ts
+++ b/src/models/ResponseModel.ts
@@ -1,12 +1,12 @@
 /**
- * HTTP headers to be included in all responses.
+ * HTTP headers to be included in `ResponseModel`.
  */
-export const RESPONSE_HEADERS = {
+export const RESPONSE_HEADERS: Record<string, string> = {
   'Content-Type': 'application/json',
   /** Required for CORS support to work */
   'Access-Control-Allow-Origin': '*',
   /** Required for cookies, authorization headers with HTTPS */
-  'Access-Control-Allow-Credentials': true,
+  'Access-Control-Allow-Credentials': 'true',
 };
 
 /**

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -1,7 +1,7 @@
 import DependencyAwareClass from '@/src/core/DependencyAwareClass';
 import DependencyInjection from '@/src/core/DependencyInjection';
 import LambdaWrapper from '@/src/core/LambdaWrapper';
-import ResponseModel from '@/src/models/ResponseModel';
+import ResponseModel, { RESPONSE_HEADERS } from '@/src/models/ResponseModel';
 import SQSMessageModel from '@/src/models/SQSMessageModel';
 import StatusModel from '@/src/models/StatusModel';
 import BaseConfigService from '@/src/services/BaseConfigService';
@@ -45,6 +45,7 @@ describe('unit.index', () => {
 
   it('should export ResponseModel', () => {
     expect(lib.ResponseModel).toBe(ResponseModel);
+    expect(lib.RESPONSE_HEADERS).toBe(RESPONSE_HEADERS);
   });
 
   it('should export SQSMessageModel', () => {


### PR DESCRIPTION
Makes `RESPONSE_HEADERS` available for import from the package index. This is useful if you want to change the default headers in your responses, e.g. to change `Content-Type`.

The type is also relaxed to `Record<string, string>` to allow adding or removing headers.

BREAKING CHANGE: the `Access-Control-Allow-Credentials` header value is now the string `'true'` instead of Boolean `true`.