### PR TITLE
docs: Show how to install the beta version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If you're coming from v1 and updating to v2, check out the [v2 migration guide](
 Install via npm or Yarn:
 
 ```bash
-npm i @comicrelief/lambda-wrapper
+npm i @comicrelief/lambda-wrapper@beta
 # or
-yarn add @comicrelief/lambda-wrapper
+yarn add @comicrelief/lambda-wrapper@beta
 ```
 
 You can then wrap your Lambda handler functions like this:


### PR DESCRIPTION
So that someone looking at the `beta` branch gets instructions that they can follow to install this version.

This will need reverting just before we merge `beta` into `master`.