### PR TITLE
feat: Propagate config type to dependencies

### DIFF
--- a/src/core/DependencyAwareClass.ts
+++ b/src/core/DependencyAwareClass.ts
@@ -1,10 +1,11 @@
 import DependencyInjection from './DependencyInjection';
+import { LambdaWrapperConfig } from './config';
 
 /**
  * Base class for dependencies.
  */
-export default class DependencyAwareClass {
-  constructor(readonly di: DependencyInjection) {}
+export default class DependencyAwareClass<TConfig extends LambdaWrapperConfig = any> {
+  constructor(readonly di: DependencyInjection<TConfig>) {}
 
   /**
    * Get dependency injection container.

--- a/src/core/DependencyInjection.ts
+++ b/src/core/DependencyInjection.ts
@@ -4,7 +4,7 @@ import DependencyAwareClass from './DependencyAwareClass';
 import { LambdaWrapperConfig } from './config';
 
 // eslint-disable-next-line no-use-before-define
-type Class<T> = new (di: DependencyInjection) => T;
+type Class<TInstance, TConfig extends LambdaWrapperConfig> = new (di: DependencyInjection<TConfig>) => TInstance;
 
 /**
  * Dependency injection container.
@@ -12,7 +12,7 @@ type Class<T> = new (di: DependencyInjection) => T;
  * Dependencies (singleton instances of dependency-aware classes) are provided
  * to the main Lambda handler and other dependencies via this class.
  */
-export default class DependencyInjection {
+export default class DependencyInjection<TConfig extends LambdaWrapperConfig = any> {
   /**
    * Instantiated dependencies.
    */
@@ -24,7 +24,7 @@ export default class DependencyInjection {
   private isConstructing = true;
 
   constructor(
-    readonly config: LambdaWrapperConfig,
+    readonly config: TConfig,
     readonly event: any,
     readonly context: Context,
   ) {
@@ -41,7 +41,7 @@ export default class DependencyInjection {
    *
    * @param dependency
    */
-  get<T extends DependencyAwareClass>(dependency: Class<T>): T {
+  get<T extends DependencyAwareClass>(dependency: Class<T, TConfig>): T {
     if (this.isConstructing) {
       throw new Error(
         'Dependencies are not available in dependency class constructors.\n\n'

--- a/src/core/LambdaWrapper.ts
+++ b/src/core/LambdaWrapper.ts
@@ -34,7 +34,7 @@ export default class LambdaWrapper<TConfig extends LambdaWrapperConfig = LambdaW
   /**
    * Wrap the given function.
    */
-  wrap<T>(handler: (di: DependencyInjection) => Promise<T>, options?: WrapOptions) {
+  wrap<T>(handler: (di: DependencyInjection<TConfig>) => Promise<T>, options?: WrapOptions) {
     const {
       handleUncaughtErrors = true,
     } = options || {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export {
 } from './services/RequestService';
 export {
   default as SQSService,
+  QueueName,
   SQS_OFFLINE_MODES,
   SQS_PUBLISH_FAILURE_MODES,
   SQSServiceConfig,

--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -115,7 +115,7 @@ export const SQS_PUBLISH_FAILURE_MODES = {
  *   sqs: {
  *     queues: {
  *       // add an entry for each queue mapping to its AWS name
- *       submissions: process.env.SQS_QUEUE_SUBMISSIONS,
+ *       submissions: process.env.SQS_QUEUE_SUBMISSIONS as string,
  *     },
  *   },
  * });
@@ -131,6 +131,72 @@ export const SQS_PUBLISH_FAILURE_MODES = {
  *   await sqs.publish('submissions', message);
  * });
  * ```
+ *
+ * When using TypeScript, queue names are inferred from your Lambda Wrapper
+ * config so that IntelliSense can provide hints and TypeScript will tell you
+ * at compile-time if you try to publish to an undefined queue.
+ *
+ * ```ts
+ * // ok
+ * await sqs.publish('submissions', message);
+ *
+ * // error: Argument of type '"submission"' is not assignable to parameter of
+ * // type '"submissions"'.
+ * await sqs.publish('submission', message);
+ * ```
+ *
+ * Note that if you're passing the queue name in as a variable, you'll need to
+ * ensure the variable type is specific enough and not simply `string`. If you
+ * have a list of queue names you will need to declare it `as const`. Otherwise,
+ * use string literal types, or the `QueueName` generic type which extracts the
+ * type of all queue names from your Lambda Wrapper config.
+ *
+ * ```ts
+ * const myQueues = ['queue1', 'queue2'];
+ * for (const queue of myQueues) {
+ *   // won't compile because `queue` is of type `string`
+ *   await sqs.publish(queue, message);
+ * }
+ *
+ * const myQueues = ['queue1', 'queue2'] as const;
+ * for (const queue of myQueues) {
+ *   // ok now because `queue` is of type `"queue1" | "queue2"`
+ *   await sqs.publish(queue, message);
+ * }
+ *
+ * // you can also simply use string literal types
+ * let queue: "queue1" | "queue2";
+ *
+ * // or accept any queue defined in the config using `QueueName`
+ * let queue: QueueName<typeof lambdaWrapper.config>;
+ * ```
+ *
+ * This is all pretty cool, but the current implementation has a caveat: the
+ * `WithSQSServiceConfig` type has to be a little vague about `sqs.queues` in
+ * order to get TypeScript to infer its keys. The following config will not
+ * raise any errors itself, but is invalid and will make the `QueueName` type
+ * `never`.
+ *
+ * ```ts
+ * lambdaWrapper.configure<WithSQSServiceConfig>({
+ *   sqs: {
+ *     queues: {
+ *       good: 'good-queue',
+ *       bad: 0, // oops, not a string, but no errors here!
+ *     },
+ *   },
+ * });
+ *
+ * // even though this is queue has valid config, the invalid one breaks it:
+ * // Argument of type 'string' is not assignable to parameter of type 'never'.
+ * await sqs.publish('good', message);
+ * ```
+ *
+ * If you start getting _not assignable to parameter of type 'never'_ errors on
+ * all your `SQSService` method calls, double-check that your config is correct.
+ * Be particularly careful with environment variables – by default they have
+ * type `string | undefined`. In the first example at the top of this page, a
+ * type assertion was used to coerce this to `string`.
  */
 export default class SQSService<TConfig extends LambdaWrapperConfig & WithSQSServiceConfig> extends DependencyAwareClass {
   readonly queues: Record<QueueName<TConfig>, string>;

--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -198,7 +198,9 @@ export const SQS_PUBLISH_FAILURE_MODES = {
  * type `string | undefined`. In the first example at the top of this page, a
  * type assertion was used to coerce this to `string`.
  */
-export default class SQSService<TConfig extends LambdaWrapperConfig & WithSQSServiceConfig> extends DependencyAwareClass {
+export default class SQSService<
+  TConfig extends LambdaWrapperConfig & WithSQSServiceConfig = any,
+> extends DependencyAwareClass {
   readonly queues: Record<QueueName<TConfig>, string>;
 
   readonly queueConsumers: Record<QueueName<TConfig>, string>;

--- a/tests/unit/services/SQSService.spec.ts
+++ b/tests/unit/services/SQSService.spec.ts
@@ -1,17 +1,15 @@
 import {
   Context,
   DependencyInjection,
-  LambdaWrapperConfig,
   LoggerService,
   SQSService,
   SQS_PUBLISH_FAILURE_MODES,
   TimerService,
-  WithSQSServiceConfig,
 } from '@/src';
 
 const TEST_QUEUE = 'TEST_QUEUE';
 
-const config: LambdaWrapperConfig & WithSQSServiceConfig = {
+const config = {
   dependencies: {
     SQSService,
     LoggerService,
@@ -35,6 +33,15 @@ const createAsyncMock = (returnValue: any) => {
   return jest.fn().mockReturnValue({ promise: () => mockedValue });
 };
 
+type MockSQSService = SQSService<typeof config> & {
+  sqs: {
+    sendMessage: jest.Mock;
+  };
+  lambda: {
+    invoke: jest.Mock;
+  }
+};
+
 /**
  * Generates a SQSService
  *
@@ -47,7 +54,7 @@ const getService = (
     invoke = null,
   }: any = {},
   isOffline = false,
-): SQSService & { sqs: { sendMessage: jest.Mock }; lambda: { invoke: jest.Mock } } => {
+): MockSQSService => {
   const di = new DependencyInjection(config, {}, {
     invokedFunctionArn: isOffline ? 'offline' : 'arn:aws:lambda:eu-west-1:0123456789:test',
   } as Context);


### PR DESCRIPTION
Dependency-aware classes can now access the type of the Lambda Wrapper config. This opens the door to using information from the config to better type some methods.

As an example, our `SQSService` has many methods that take a queue name. Previously these had to be type `string` and we relied on runtime checks to ensure valid queue names were passed in. With access to the config type, we can infer queue names from the keys of `config.sqs.queues`, so this check can now be done at compile-time, _and_ we get IntelliSense suggestions for queue names!

This is still a work in progress, although potentially useful and usable enough in its current state to release to beta. See the updated documentation for known issues.

There should be no breaking changes. All new type parameters are optional. Unrecognised SQS queue names will raise compiler errors now, however these should not exist in a working application.