### PR TITLE
fix: Add missing space in DI error message

### DIFF
--- a/src/core/DependencyInjection.ts
+++ b/src/core/DependencyInjection.ts
@@ -45,7 +45,7 @@ export default class DependencyInjection {
     if (this.isConstructing) {
       throw new Error(
         'Dependencies are not available in dependency class constructors.\n\n'
-        + 'To fix this, call `di.get` in the function where the dependency is'
+        + 'To fix this, call `di.get` in the function where the dependency is '
         + 'used instead of inside your constructor.',
       );
     }


### PR DESCRIPTION
Hidden because it was on a line join.