### PR TITLE
fix: Allow synchronous handlers

### DIFF
--- a/src/core/LambdaWrapper.ts
+++ b/src/core/LambdaWrapper.ts
@@ -34,7 +34,10 @@ export default class LambdaWrapper<TConfig extends LambdaWrapperConfig = LambdaW
   /**
    * Wrap the given function.
    */
-  wrap<T>(handler: (di: DependencyInjection<TConfig>) => Promise<T>, options?: WrapOptions) {
+  wrap<T>(
+    handler: (di: DependencyInjection<TConfig>) => T | Promise<T>,
+    options?: WrapOptions,
+  ) {
     const {
       handleUncaughtErrors = true,
     } = options || {};


### PR DESCRIPTION
The current type of `LambdaWrapper#wrap` requires handlers to return a `Promise`. We should support synchronous handlers too.

No implementation change is required – they're already supported, just disallowed by the type system.

Jira: [ENG-2732]

[ENG-2732]: https://comicrelief.atlassian.net/browse/ENG-2732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ