### PR TITLE
feat: Return lowercase header keys from `getAllHeaders`

### DIFF
--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -5,6 +5,8 @@ This doc summarises the breaking changes introduced in v2 and what you need to d
 - [Configuration](#configuration)
 - [Wrapping a function](#wrapping-a-function)
 - [Dependency injection](#dependency-injection)
+- [Services](#services)
+  - [RequestService](#requestservice)
 - [Models](#models)
   - [StatusModel](#statusmodel)
 
@@ -149,6 +151,14 @@ export default lambdaWrapper.wrap(async (di) => {
 The `definitions` property has been removed.
 
 The `getEvent`, `getContext` and `getConfiguration` methods have been deprecated and will be removed in a future major release. Use the `event`, `context` and `config` properties directly.
+
+## Services
+
+There are some small breaking changes to the built-in services. We've tried to minimise disruption here, so most of these are unlikely to affect real-world applications, but are included in the 2.0.0 release as a precaution.
+
+### `RequestService`
+
+Header names returned by `getAllHeaders` are now lowercased. This is consistent with many other libraries (e.g. `http`, `axios`) and makes it easier to work with HTTP headers. In some cases it may be easier to change existing code to use `getHeader`, which has provided case-insensitive access to headers since [v1.2.0](https://github.com/comicrelief/lambda-wrapper/releases/tag/v1.2.0).
 
 ## Models
 

--- a/docs/services/RequestService.md
+++ b/docs/services/RequestService.md
@@ -19,8 +19,8 @@ export default lambdaWrapper.wrap(async (di) => {
 
 ### Headers
 
-- `getAllHeaders` returns an object containing all headers, with all keys lowercase
-- `getHeader` returns the value of an HTTP header
+- `getAllHeaders` returns an object containing all HTTP headers, with all keys lowercase
+- `getHeader` returns the value of a single HTTP header
 - `getAuthorizationToken` extracts a Bearer token from the `Authorization` header
 
 ### Body

--- a/docs/services/RequestService.md
+++ b/docs/services/RequestService.md
@@ -19,7 +19,7 @@ export default lambdaWrapper.wrap(async (di) => {
 
 ### Headers
 
-- `getAllHeaders` returns an object containing all headers
+- `getAllHeaders` returns an object containing all headers, with all keys lowercase
 - `getHeader` returns the value of an HTTP header
 - `getAuthorizationToken` extracts a Bearer token from the `Authorization` header
 

--- a/src/services/RequestService.ts
+++ b/src/services/RequestService.ts
@@ -68,11 +68,19 @@ export default class RequestService extends DependencyAwareClass {
   /**
    * Get all HTTP headers included in the request.
    *
+   * Header names are converted to lowercase.
+   *
    * @returns An object with a key for each header.
    */
   getAllHeaders() {
-    const event = this.getContainer().getEvent() as APIGatewayProxyEvent;
-    return { ...event.headers };
+    const event = this.di.event as APIGatewayProxyEvent;
+    if (!event.headers) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(event.headers)
+        .map(([key, value]) => [key.toLowerCase(), value]),
+    );
   }
 
   /**
@@ -90,8 +98,7 @@ export default class RequestService extends DependencyAwareClass {
       return whenMissing;
     }
     const lowerName = name.toLowerCase();
-    const key = Object.keys(headers).find((k) => k.toLowerCase() === lowerName);
-    return (key && headers[key]) || whenMissing;
+    return headers[lowerName] ?? whenMissing;
   }
 
   /**

--- a/src/services/RequestService.ts
+++ b/src/services/RequestService.ts
@@ -94,9 +94,6 @@ export default class RequestService extends DependencyAwareClass {
    */
   getHeader(name: string, whenMissing = ''): string {
     const headers = this.getAllHeaders();
-    if (!headers) {
-      return whenMissing;
-    }
     const lowerName = name.toLowerCase();
     return headers[lowerName] ?? whenMissing;
   }

--- a/src/services/RequestService.ts
+++ b/src/services/RequestService.ts
@@ -72,7 +72,7 @@ export default class RequestService extends DependencyAwareClass {
    *
    * @returns An object with a key for each header.
    */
-  getAllHeaders() {
+  getAllHeaders(): Record<string, string | undefined> {
     const event = this.di.event as APIGatewayProxyEvent;
     if (!event.headers) {
       return {};

--- a/tests/unit/services/RequestService.spec.ts
+++ b/tests/unit/services/RequestService.spec.ts
@@ -230,7 +230,35 @@ describe('unit.services.RequestService', () => {
     const request = getRequestService(event);
 
     it('should return all headers from the event', () => {
-      expect(request.getAllHeaders()).toStrictEqual(event.headers);
+      const result = request.getAllHeaders();
+      expect(result).toEqual({
+        /* eslint-disable quote-props */
+        'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'accept-encoding': 'gzip, deflate',
+        'accept-language': 'en-us',
+        'cloudfront-forwarded-proto': 'https',
+        'cloudfront-is-desktop-viewer': 'true',
+        'cloudfront-is-mobile-viewer': 'false',
+        'cloudfront-is-smarttv-viewer': 'false',
+        'cloudfront-is-tablet-viewer': 'false',
+        'cloudfront-viewer-country': 'US',
+        'cookie': '__gads=ID=d51d609e5753330d:T=1443694116:S=ALNI_MbjWKzLwdEpWZ5wR5WXRI2dtjIpHw; __qca=P0-179798513-1443694132017; _ga=GA1.2.344061584.1441769647',
+        'host': 'xxx.execute-api.us-east-1.amazonaws.com',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/601.6.17 (KHTML, like Gecko) Version/9.1.1 Safari/601.6.17',
+        'via': '1.1 c8a5bb0e20655459eaam174e5c41443b.cloudfront.net (CloudFront)',
+        'x-amz-cf-id': 'z7Ds7oXaY8hgUn7lcedZjoIoxyvnzF6ycVzBdQmhn3QnOPEjJz4BrQ==',
+        'x-forwarded-for': '221.24.103.21, 54.242.148.216',
+        'x-forwarded-port': '443',
+        'x-forwarded-proto': 'https',
+        /* eslint-enable quote-props */
+      });
+    });
+
+    it('should convert header names to lowercase', () => {
+      const result = request.getAllHeaders();
+      Object.keys(result).forEach((name) => {
+        expect(name).toEqual(name.toLowerCase());
+      });
     });
   });
 


### PR DESCRIPTION
This is consistent with many other libraries (e.g. http, axios) and makes it easier to work with HTTP headers.

The HTTP protocol states that header names are case-insensitive, so currently when using `getAllHeaders` you must worry about the case of the header name:

```js
const headers = request.getAllHeaders();
const contentType = headers['Content-Type'] || headers['content-type'];
// but what if someone sends us `Content-type`?
```

The existing `getHeader` method solved this by doing a case-insensitive search of all keys. Now, you can also safely use the lowercase key:

```js
const headers = request.getAllHeaders();
const contentType = headers['content-type'];
```

Jira: [ENG-2735]

BREAKING CHANGE: Header keys returned by `getAllHeaders` are converted to lowercase. Accessing headers through non-lowercase keys will yield `undefined`, even if the header in the request is in the same case. Use lowercase keys, or use `getHeader`.

[ENG-2735]: https://comicrelief.atlassian.net/browse/ENG-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ