### PR TITLE
feat: `SQSMessageModel` checks message has required fields

### DIFF
--- a/src/models/SQSMessageModel.ts
+++ b/src/models/SQSMessageModel.ts
@@ -15,10 +15,24 @@ export default class Message {
   metadata: Record<string, any> = {};
 
   constructor(message: SQS.Message) {
-    // todo: validate rather than assert the type
-    this.messageId = message.MessageId!;
-    this.receiptHandle = message.ReceiptHandle!;
-    this.body = JSON.parse(message.Body!);
+    if (!message.MessageId) {
+      throw new TypeError('Message does not have a MessageId');
+    }
+    if (!message.ReceiptHandle) {
+      throw new TypeError('Message does not have a ReceiptHandle');
+    }
+    if (!message.Body) {
+      throw new TypeError('Message does not have a Body');
+    }
+
+    this.messageId = message.MessageId;
+    this.receiptHandle = message.ReceiptHandle;
+
+    try {
+      this.body = JSON.parse(message.Body);
+    } catch (error) {
+      throw new TypeError('Message body is not valid JSON');
+    }
   }
 
   /**


### PR DESCRIPTION
Allows us to remove the non-null assertions, making this model more type-safe.

This is unlikely to break any existing applications as this model is intended for _received_ messages, which have all required fields.

BREAKING CHANGE: `SQSMessageModel` will throw if required fields (`MessageID`, `ReceiptHandle`, `Body`) are missing from the SQS message.