### PR TITLE
fix: Improve `SQSMessageModel` types

### DIFF
--- a/src/models/SQSMessageModel.ts
+++ b/src/models/SQSMessageModel.ts
@@ -24,21 +24,21 @@ export default class Message {
   /**
    * Get message ID.
    */
-  getMessageId() {
+  getMessageId(): string {
     return this.messageId;
   }
 
   /**
    * Get message receipt handle.
    */
-  getReceiptHandle() {
+  getReceiptHandle(): string {
     return this.receiptHandle;
   }
 
   /**
    * Get message body.
    */
-  getBody() {
+  getBody(): unknown {
     return this.body;
   }
 
@@ -47,21 +47,21 @@ export default class Message {
    *
    * @param forDeletion
    */
-  setForDeletion(forDeletion: boolean) {
+  setForDeletion(forDeletion: boolean): void {
     this.forDeletion = forDeletion;
   }
 
   /**
    * Whether message is for deletion.
    */
-  isForDeletion() {
+  isForDeletion(): boolean {
     return this.forDeletion;
   }
 
   /**
    * Get all of the message metadata.
    */
-  getMetaData() {
+  getMetaData(): Record<string, any> {
     return this.metadata;
   }
 
@@ -71,7 +71,7 @@ export default class Message {
    * @param key
    * @param value
    */
-  setMetaData(key: string, value: any) {
+  setMetaData(key: string, value: any): this {
     this.metadata[key] = value;
 
     return this;

--- a/src/models/SQSMessageModel.ts
+++ b/src/models/SQSMessageModel.ts
@@ -4,15 +4,15 @@ import { SQS } from 'aws-sdk';
  * Message model for SQS.
  */
 export default class Message {
-  messageId: string;
+  readonly messageId: string;
 
-  receiptHandle: string;
+  readonly receiptHandle: string;
 
-  body: string;
+  readonly body: string;
+
+  readonly metadata: Record<string, any> = {};
 
   forDeletion = false;
-
-  metadata: Record<string, any> = {};
 
   constructor(message: SQS.Message) {
     // todo: validate rather than assert the type

--- a/src/models/SQSMessageModel.ts
+++ b/src/models/SQSMessageModel.ts
@@ -8,7 +8,7 @@ export default class Message {
 
   readonly receiptHandle: string;
 
-  readonly body: string;
+  readonly body: unknown;
 
   readonly metadata: Record<string, any> = {};
 


### PR DESCRIPTION
Further work to make `SQSMessageModel` more type-safe.

- Properties that have only a getter (no setter) are made readonly
- `body` type changed from `string` (incorrect) to `unknown`

Jira: [ENG-2733]

[ENG-2733]: https://comicrelief.atlassian.net/browse/ENG-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ