### PR TITLE
refactor: Rename SQS message model class

### DIFF
--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -201,3 +201,7 @@ async function checkStatus(): Promise<ServiceStatus> {
 ```
 
 Note that we can keep `status` unset initially, and TypeScript will complain if you forget to set it before `checkStatus` returns.
+
+### `SQSMessageModel`
+
+The class name has changed from `Message` to `SQSMessageModel` in order to be consistent with the name exported from the package index. This is not expected to break anything, and does not affect imports because the class is a default export.

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -9,6 +9,7 @@ This doc summarises the breaking changes introduced in v2 and what you need to d
   - [RequestService](#requestservice)
 - [Models](#models)
   - [StatusModel](#statusmodel)
+  - [SQSMessageModel](#sqsmessagemodel)
 
 The new version of dependency injection does not work if code is minified. See [Notes](../../README.md#notes) in the main readme for how to turn this off in webpack.
 

--- a/src/models/SQSMessageModel.ts
+++ b/src/models/SQSMessageModel.ts
@@ -3,7 +3,7 @@ import { SQS } from 'aws-sdk';
 /**
  * Message model for SQS.
  */
-export default class Message {
+export default class SQSMessageModel {
   messageId: string;
 
   receiptHandle: string;


### PR DESCRIPTION
Change the name of the class to match the name exported from the package index.

This should not be a breaking change because the class is the default export of its module. Just in case there is some contrived case that depends on the class's `name` attribute, we'll include this in the v2.0.0 major release.

Jira: [ENG-2733]

[ENG-2733]: https://comicrelief.atlassian.net/browse/ENG-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ