### PR TITLE
fix: Improve type of `configure` config param

### DIFF
--- a/src/core/LambdaWrapper.ts
+++ b/src/core/LambdaWrapper.ts
@@ -27,7 +27,7 @@ export default class LambdaWrapper<TConfig extends LambdaWrapperConfig = LambdaW
    *
    * @param config
    */
-  configure<TMoreConfig>(config: Partial<TConfig> & TMoreConfig): LambdaWrapper<TConfig & TMoreConfig> {
+  configure<TMoreConfig extends Partial<LambdaWrapperConfig>>(config: Partial<TConfig> & TMoreConfig): LambdaWrapper<TConfig & TMoreConfig> {
     return new LambdaWrapper(mergeConfig(this.config, config));
   }
 


### PR DESCRIPTION
This allows IntelliSense to suggest the `dependencies` key (and any other existing config keys) when you are entering the config parameter.

The `TMoreConfig` type, which is used to track the addition of arbitrary keys to the Lambda Wrapper config object, was not constrained and so could be inferred as `any`.

The type of the `config` param therefore defaulted to `Partial<TConfig> & any`. This is equivalent to `any`, and IntelliSense cannot make suggestions about keys that may be available.

By requiring `TMoreConfig` to extend `Partial<LambdaWrapperConfig>`, we still allow any object but tell the type system about expected optional keys, so IntelliSense can suggest them.

Jira: [ENG-3163]

[ENG-3163]: https://comicrelief.atlassian.net/browse/ENG-3163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ