### PR TITLE
feat: Runtime config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ export default class MyService extends DependencyAwareClass {
 }
 ```
 
+If you need to override the constructor, it must take a `DependencyInjection` instance and pass it to `super`.
+
+```ts
+export default class MyService extends DependencyAwareClass {
+  constructor(di: DependencyInjection) {
+    super(di);
+    // now do your other constructor stuff
+  }
+}
+```
+
 Then add it to your Lambda Wrapper configuration in the `dependencies` key.
 
 ```ts

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -150,6 +150,8 @@ export default lambdaWrapper.wrap(async (di) => {
 
 `get` will also always throw an error when used in a constructor to avoid surprises where other dependencies may be `undefined`. Instead of storing references to dependencies in class members, `get` them just before use.
 
+A further breaking change in v2 is that all dependencies _must_ extend `DependencyAwareClass`. This is enforced at the type level and also at runtime, for those using plain JavaScript. Remember to add a call to `super` if you are overriding the constructor.
+
 The `definitions` property has been removed.
 
 The `getEvent`, `getContext` and `getConfiguration` methods have been deprecated and will be removed in a future major release. Use the `event`, `context` and `config` properties directly.

--- a/src/core/LambdaWrapper.ts
+++ b/src/core/LambdaWrapper.ts
@@ -22,7 +22,7 @@ export interface WrapOptions {
 
 export default class LambdaWrapper<TConfig extends LambdaWrapperConfig = LambdaWrapperConfig> {
   constructor(readonly config: TConfig) {
-    LambdaWrapper.validateConfiguration(config);
+    LambdaWrapper.validateConfig(config);
   }
 
   /**
@@ -33,7 +33,7 @@ export default class LambdaWrapper<TConfig extends LambdaWrapperConfig = LambdaW
    *
    * @param config
    */
-  static validateConfiguration(config: LambdaWrapperConfig): void {
+  static validateConfig(config: LambdaWrapperConfig): void {
     if (!config.dependencies) {
       throw new TypeError("config is missing the 'dependencies' key");
     }

--- a/tests/unit/core/LambdaWrapper.spec.ts
+++ b/tests/unit/core/LambdaWrapper.spec.ts
@@ -34,7 +34,7 @@ describe('unit.core.LambdaWrapper', () => {
 
   afterEach(() => jest.resetAllMocks());
 
-  describe('validateConfiguration', () => {
+  describe('validateConfig', () => {
     describe('valid config', () => {
       ([
         {
@@ -61,7 +61,7 @@ describe('unit.core.LambdaWrapper', () => {
         },
       ] as const).forEach(({ name, input }) => {
         it(`should pass on valid config: ${name}`, () => {
-          expect(() => LambdaWrapper.validateConfiguration(input)).not.toThrow();
+          expect(() => LambdaWrapper.validateConfig(input)).not.toThrow();
         });
       });
     });

--- a/tests/unit/core/LambdaWrapper.spec.ts
+++ b/tests/unit/core/LambdaWrapper.spec.ts
@@ -1,6 +1,7 @@
 import { RESPONSE_HEADERS } from '@/src/models/ResponseModel';
 
 import {
+  DependencyAwareClass,
   DependencyInjection,
   LambdaTermination,
   LambdaWrapper,
@@ -32,6 +33,55 @@ describe('unit.core.LambdaWrapper', () => {
   });
 
   afterEach(() => jest.resetAllMocks());
+
+  describe('validateConfiguration', () => {
+    describe('valid config', () => {
+      ([
+        {
+          name: 'empty',
+          input: {
+            dependencies: {},
+          },
+        },
+        {
+          name: 'good dependency',
+          input: {
+            dependencies: {
+              Good: class Good extends DependencyAwareClass {},
+            },
+          },
+        },
+        {
+          name: 'extra keys',
+          input: {
+            dependencies: {},
+            sqs: {},
+            extra: {},
+          },
+        },
+      ] as const).forEach(({ name, input }) => {
+        it(`should pass on valid config: ${name}`, () => {
+          expect(() => LambdaWrapper.validateConfiguration(input)).not.toThrow();
+        });
+      });
+    });
+
+    describe('invalid config', () => {
+      // these scenarios are prevented by TypeScript, but may happen in plain JS
+
+      it('should throw if config is missing dependencies', () => {
+        expect(() => new LambdaWrapper({} as any)).toThrow(TypeError);
+      });
+
+      it('should throw if a dependency does not extend DependencyAwareClass', () => {
+        expect(() => new LambdaWrapper({
+          dependencies: {
+            Bad: class Bad {},
+          },
+        } as any)).toThrow(TypeError);
+      });
+    });
+  });
 
   describe('config', () => {
     it('should expose the config object', () => {


### PR DESCRIPTION
Adds some basic config validation at runtime, which will help avoid problems in projects that are not using TypeScript. In particular, we will now throw an error if a dependency does not extend `DependencyAwareClass`.

Not marking this as a separate breaking change because bad configs will already cause compile-time errors in TypeScript.

Jira: [ENG-3207]

[ENG-3207]: https://comicrelief.atlassian.net/browse/ENG-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ