### PR TITLE
docs: Remove refs to beta ahead of 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If you're coming from v1 and updating to v2, check out the [v2 migration guide](
 Install via npm or Yarn:
 
 ```bash
-npm i @comicrelief/lambda-wrapper@beta
+npm i @comicrelief/lambda-wrapper
 # or
-yarn add @comicrelief/lambda-wrapper@beta
+yarn add @comicrelief/lambda-wrapper
 ```
 
 You can then wrap your Lambda handler functions like this:

--- a/src/core/DependencyInjection.ts
+++ b/src/core/DependencyInjection.ts
@@ -51,7 +51,7 @@ export default class DependencyInjection<TConfig extends LambdaWrapperConfig = a
           + "bundler may be minifying your code. You'll need to disable this "
           + 'for Lambda Wrapper to work correctly. Please refer to the Notes '
           + 'section of the Lambda Wrapper readme:\n\n'
-          + '  https://github.com/comicrelief/lambda-wrapper/tree/beta#notes'
+          + '  https://github.com/comicrelief/lambda-wrapper#notes'
         : 'Please ensure that all dependency classes have a unique name.';
 
       throw new Error(


### PR DESCRIPTION
To be merged just before #1195, so that the docs in the 2.0.0 release do not tell you to install from the beta channel.