### PR TITLE
fix: Simplify promises and callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@sentry/node": "^6.19.7",
     "@types/aws-lambda": "^8.10.134",
     "alai": "1.0.3",
-    "async": "^3.2.5",
     "axios": "^1.6.7",
     "useragent": "2.3.0",
     "uuid": "^9.0.1",

--- a/src/services/RequestService.ts
+++ b/src/services/RequestService.ts
@@ -259,18 +259,15 @@ export default class RequestService extends DependencyAwareClass {
   validateAgainstConstraints(constraints: object): Promise<void> {
     const logger = this.di.get(LoggerService);
 
-    return new Promise((resolve, reject) => {
-      const validation = validate(this.getAll(), constraints);
+    const validation = validate(this.getAll(), constraints);
+    if (typeof validation === 'undefined') {
+      return Promise.resolve();
+    }
 
-      if (typeof validation === 'undefined') {
-        resolve();
-      } else {
-        logger.label('request-validation-failed');
-        const validationErrorResponse = ERROR_TYPES.VALIDATION_ERROR;
-        validationErrorResponse.setBodyVariable('validation_errors', validation);
-        reject(validationErrorResponse);
-      }
-    });
+    logger.label('request-validation-failed');
+    const validationErrorResponse = ERROR_TYPES.VALIDATION_ERROR;
+    validationErrorResponse.setBodyVariable('validation_errors', validation);
+    return Promise.reject(validationErrorResponse);
   }
 
   /**

--- a/tests/unit/services/SQSService.spec.ts
+++ b/tests/unit/services/SQSService.spec.ts
@@ -33,18 +33,9 @@ const createAsyncMock = (returnValue: any) => {
   return jest.fn().mockReturnValue({ promise: () => mockedValue });
 };
 
-const createCallbackMock = (returnValue: any) => jest.fn()
-  .mockImplementation((...args: any[]) => {
-    const callback = args.pop();
-    if (returnValue instanceof Error) {
-      callback(returnValue, {});
-    } else {
-      callback(null, returnValue);
-    }
-  });
-
 type MockSQSService = SQSService<typeof config> & {
   sqs: {
+    listQueues: jest.Mock;
     sendMessage: jest.Mock;
   };
   lambda: {
@@ -75,7 +66,7 @@ const getService = (
 
   const service = di.get(SQSService);
   const sqs = {
-    listQueues: createCallbackMock(listQueues),
+    listQueues: createAsyncMock(listQueues),
     sendMessage: createAsyncMock(sendMessage),
   } as unknown as AWS.SQS;
   const lambda = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,11 +1702,6 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
-async@^3.2.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
-  integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"


### PR DESCRIPTION
Replaces some of the harder-to-understand use of callback-style async and `new Promise` with simpler async-await. As a bonus, we can remove the `async` dependency!

This also fixes a bug in `SQSService#checkStatus`, where a failed `listQueues` call can result in a `TypeError` if the `data` parameter of the callback is undefined or null. Previously the unit tests ignored this by passing an empty object (see the deleted `createCallbackMock` function).

No specific Jira ticket, but removal of `async` completes [ENG-3212]

*edit*: and the `checkService` bugfix completes [ENG-3155]

[ENG-3212]: https://comicrelief.atlassian.net/browse/ENG-3212
[ENG-3155]: https://comicrelief.atlassian.net/browse/ENG-3155