### PR TITLE
docs: Remove refs to Epsagon in `LoggerService`

### DIFF
--- a/src/services/LoggerService.ts
+++ b/src/services/LoggerService.ts
@@ -210,7 +210,7 @@ export default class LoggerService extends DependencyAwareClass {
   }
 
   /**
-   * Add a label to the function's Epsagon trace.
+   * Add a label to the function's Lumigo trace.
    *
    * @param descriptor
    * @param silent If `false`, the label will also be logged. (default: false)
@@ -226,7 +226,7 @@ export default class LoggerService extends DependencyAwareClass {
   }
 
   /**
-   * Add a metric to the function's Epsagon trace.
+   * Add a metric to the function's Lumigo trace.
    *
    * @param descriptor
    * @param stat


### PR DESCRIPTION
Updates some old JSDoc comments to say Lumigo instead.

Jira: [ENG-3412]

[ENG-3412]: https://comicrelief.atlassian.net/browse/ENG-3412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ