### PR TITLE
feat: Allow short function names in queue consumer config

### DIFF
--- a/docs/services/SQSService.md
+++ b/docs/services/SQSService.md
@@ -117,14 +117,10 @@ To take advantage of SQS emulation, you will need to do the following in your pr
   const lambdaWrapper = lw.configure({
     sqs: {
       queues: {
-        // Add an entry for each queue with its AWS name.
-        // Usually we define queue names in our serverless.yml and provide them
-        // to the application via environment variables. If you haven't defined
-        // types for your env vars, you'll need to coerce them to `string`.
         submissions: process.env.SQS_QUEUE_SUBMISSIONS as string,
       },
       queueConsumers: {
-        // See section below about offline SQS emulation.
+        // add an entry mapping each queue to its consumer function name
         submissions: 'SubmissionConsumer',
       },
     }

--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -478,14 +478,18 @@ export default class SQSService<
       throw new Error('Can only publishOffline while running serverless offline.');
     }
 
-    const FunctionName = this.queueConsumers[queue];
-
-    if (!FunctionName) {
+    const consumerFunction = this.queueConsumers[queue];
+    if (!consumerFunction) {
       throw new Error(
         `Queue consumer for queue ${queue} was not found. Please add it to `
         + 'the sqs.queueConsumers key in your Lambda Wrapper config.',
       );
     }
+
+    const prefix = this.di.getLambdaPrefix();
+    const FunctionName = consumerFunction.startsWith(prefix)
+      ? consumerFunction
+      : `${prefix}${consumerFunction}`;
 
     const InvocationType = 'RequestResponse';
 

--- a/tests/mocks/aws/context.json
+++ b/tests/mocks/aws/context.json
@@ -1,3 +1,4 @@
 {
+  "functionName": "service-stage-FunctionName",
   "invokedFunctionArn": "offline"
 }

--- a/tests/unit/core/DependencyInjection.spec.ts
+++ b/tests/unit/core/DependencyInjection.spec.ts
@@ -113,4 +113,39 @@ describe('unit.core.DependencyInjection', () => {
       expect(di.getConfiguration()).toBe(mockConfig);
     });
   });
+
+  describe('getLambdaPrefix', () => {
+    describe('when STAGE and functionName are set', () => {
+      beforeAll(() => {
+        process.env.STAGE = 'stage';
+        mockContext.functionName = 'service-stage-FunctionName';
+      });
+
+      it('should return `service-stage-` prefix', () => {
+        expect(di.getLambdaPrefix()).toEqual('service-stage-');
+      });
+    });
+
+    describe('when STAGE is not set', () => {
+      beforeAll(() => {
+        delete process.env.STAGE;
+        mockContext.functionName = 'service-stage-FunctionName';
+      });
+
+      it('should throw', () => {
+        expect(() => di.getLambdaPrefix()).toThrow('STAGE is not set');
+      });
+    });
+
+    describe('when functionName is not set', () => {
+      beforeAll(() => {
+        process.env.STAGE = 'stage';
+        mockContext.functionName = '';
+      });
+
+      it('should throw', () => {
+        expect(() => di.getLambdaPrefix()).toThrow('function name is unavailable');
+      });
+    });
+  });
 });

--- a/tests/unit/services/SQSService.spec.ts
+++ b/tests/unit/services/SQSService.spec.ts
@@ -16,8 +16,10 @@ import {
   SQS_PUBLISH_FAILURE_MODES,
   TimerService,
 } from '@/src';
+import { mockContext } from '@/tests/mocks/aws';
 
 const TEST_QUEUE = 'TEST_QUEUE';
+const TEST_QUEUE_2 = 'TEST_QUEUE_2';
 
 const config = {
   dependencies: {
@@ -28,9 +30,11 @@ const config = {
   sqs: {
     queues: {
       [TEST_QUEUE]: 'QueueName',
+      [TEST_QUEUE_2]: 'QueueName',
     },
     queueConsumers: {
-      [TEST_QUEUE]: 'ConsumerFunctionName',
+      [TEST_QUEUE]: 'ShortFunctionName',
+      [TEST_QUEUE_2]: 'service-stage-FullFunctionName',
     },
   },
 };
@@ -58,9 +62,14 @@ const getService = (
   }: any = {},
   isOffline = false,
 ): MockSQSService => {
-  const di = new DependencyInjection(config, {}, {
-    invokedFunctionArn: isOffline ? 'offline' : 'arn:aws:lambda:eu-west-1:0123456789:test',
-  } as Context);
+  const context = {
+    ...mockContext,
+    invokedFunctionArn: isOffline
+      ? 'offline'
+      : `arn:aws:lambda:eu-west-1:0123456789:${mockContext.functionName}`,
+  };
+
+  const di = new DependencyInjection(config, {}, context);
 
   const logger = di.get(LoggerService);
   jest.spyOn(logger, 'error').mockImplementation();
@@ -116,6 +125,8 @@ describe('unit.services.SQSService', () => {
     envOfflineSqsHost = process.env.LAMBDA_WRAPPER_OFFLINE_SQS_HOST;
     envOfflineSqsPort = process.env.LAMBDA_WRAPPER_OFFLINE_SQS_PORT;
     envRegion = process.env.REGION;
+
+    process.env.STAGE = 'stage';
   });
 
   afterAll(() => {
@@ -228,13 +239,20 @@ describe('unit.services.SQSService', () => {
         const service = getService({}, true);
 
         await service.publish(TEST_QUEUE, { test: 1 });
+        await service.publish(TEST_QUEUE_2, { test: 2 });
 
         expect(service.sqs.send).not.toHaveBeenCalled();
-        expect(service.lambda.send).toHaveBeenCalledTimes(1);
+        expect(service.lambda.send).toHaveBeenCalledTimes(2);
 
-        const command: InvokeCommand = service.lambda.send.mock.calls[0][0];
-        expect(command).toBeInstanceOf(InvokeCommand);
-        expect(command.input.FunctionName).toEqual('ConsumerFunctionName');
+        // when a short consumer name is given, we should add the prefix
+        const command1: InvokeCommand = service.lambda.send.mock.calls[0][0];
+        expect(command1).toBeInstanceOf(InvokeCommand);
+        expect(command1.input.FunctionName).toEqual('service-stage-ShortFunctionName');
+
+        // when a full consumer name is given, we should _not_ add the prefix
+        const command2: InvokeCommand = service.lambda.send.mock.calls[1][0];
+        expect(command2).toBeInstanceOf(InvokeCommand);
+        expect(command2.input.FunctionName).toEqual('service-stage-FullFunctionName');
       });
 
       it('sends a local SQS request in "local" mode', async () => {

--- a/tests/unit/services/SQSService.spec.ts
+++ b/tests/unit/services/SQSService.spec.ts
@@ -231,7 +231,10 @@ describe('unit.services.SQSService', () => {
 
         expect(service.sqs.send).not.toHaveBeenCalled();
         expect(service.lambda.send).toHaveBeenCalledTimes(1);
-        expect(service.lambda.send).toHaveBeenCalledWith(expect.any(InvokeCommand));
+
+        const command: InvokeCommand = service.lambda.send.mock.calls[0][0];
+        expect(command).toBeInstanceOf(InvokeCommand);
+        expect(command.input.FunctionName).toEqual('ConsumerFunctionName');
       });
 
       it('sends a local SQS request in "local" mode', async () => {


### PR DESCRIPTION
Lambda Wrapper's [current documentation](https://github.com/comicrelief/lambda-wrapper/blob/0ae621606e09e23d12eff7223973431cb4710e84/docs/services/SQSService.md#direct-lambda-mode) for "direct"-mode offline SQS is incorrect: queue consumer names must be the full deployed function name generated by Serverless, typically `service-stage-FunctionName`, instead of just `FunctionName`.

However, this approach is more difficult for the developer, requiring configuration like this in order to work correctly:

```js
{
  sqs: {
    queueConsumers: {
      example: `hardcoded-service-name-${process.env.STAGE}-ConsumerFunction`,
    },
  },
}
```

In some of our services, this had been set up with hardcoded stage values, leading to unexpected issues when trying to simulate stages other than `dev` locally.

This PR allows `SQSService` to add the necessary prefix to queue consumer function names, making the previously incorrect example in the documentation work. The example given above becomes

```js
{
  sqs: {
    queueConsumers: {
      example: 'ConsumerFunction',
    },
  },
}
```

In order to maintain backwards compatibility, the prefix will not be added if it is already present. Correctly configured projects can continue to function, while projects that are broken (or broken in some stages where stage was hardcoded) will continue to be broken.

Some design decisions:

- I've placed the helper for getting the Lambda function name prefix into a public method of `DependencyInjection`, alongside the `isOffline` helper. It's not SQS-specific, and will be helpful in other scenarios where we want to invoke one Lambda function from another.

- All changes in `SQSService` are within the `publishOffline` method. I initially considered mutating the SQS config object within the constructor so that all `queueConsumer` values were converted to full function names (requiring no changes to `publishOffline`). However this creates unnecessary additional work in a deployed environment within every Lambda invocation.

Jira: [ENG-3396]