### PR TITLE
fix: Pass complete SQS event to offline queue consumer

### DIFF
--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import {
   InvokeCommand,
   LambdaClient,
@@ -13,6 +15,7 @@ import {
 } from '@aws-sdk/client-sqs';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import alai from 'alai';
+import { SQSEvent } from 'aws-lambda';
 import { v4 as uuid } from 'uuid';
 
 import DependencyAwareClass from '../core/DependencyAwareClass';
@@ -226,6 +229,8 @@ export default class SQSService<
 
   private $lambda?: LambdaClient;
 
+  private accountId?: string;
+
   constructor(di: DependencyInjection<TConfig>) {
     super(di);
 
@@ -241,7 +246,7 @@ export default class SQSService<
       REGION,
     } = process.env;
 
-    const accountId = (di.context.invokedFunctionArn && alai.parse(di.context))
+    this.accountId = (di.context.invokedFunctionArn && alai.parse(di.context))
       || AWS_ACCOUNT_ID;
 
     if (di.isOffline && !Object.values(SQS_OFFLINE_MODES).includes(offlineMode)) {
@@ -254,7 +259,7 @@ export default class SQSService<
       Object.entries(this.queues).map((
         ([key, queueName]) => [key, useLocalQueues
           ? `http://${offlineHost}:${offlinePort}/queue/${queueName}`
-          : `https://sqs.${REGION}.amazonaws.com/${accountId}/${queueName}`]
+          : `https://sqs.${REGION}.amazonaws.com/${this.accountId}/${queueName}`]
       )),
     ) as Record<QueueName<TConfig>, string>;
   }
@@ -487,20 +492,42 @@ export default class SQSService<
       );
     }
 
-    const InvocationType = 'RequestResponse';
+    const body = messageParameters.MessageBody || '';
+    const region = process.env.AWS_REGION || 'eu-west-1';
+    const timestamp = Date.now().toString();
 
-    const Payload = JSON.stringify({
+    const event: SQSEvent = {
       Records: [
         {
-          body: messageParameters.MessageBody,
+          messageId: uuid(),
+          receiptHandle: 'test',
+          body,
+          attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: timestamp,
+            SenderId: process.env.AWS_ACCESS_KEY_ID || '',
+            ApproximateFirstReceiveTimestamp: timestamp,
+          },
+          messageAttributes: {},
+          md5OfBody: createHash('md5').update(body).digest('hex'),
+          eventSource: 'aws:sqs',
+          eventSourceARN: `arn:aws:sqs:${region}:${this.accountId}:${this.queues[queue]}`,
+          awsRegion: region,
         },
       ],
-    });
+    };
+
+    if (messageParameters.MessageGroupId) {
+      const attributes = event.Records[0].attributes;
+      attributes.SequenceNumber = '0';
+      attributes.MessageGroupId = messageParameters.MessageGroupId;
+      attributes.MessageDeduplicationId = messageParameters.MessageDeduplicationId;
+    }
 
     await this.lambda.send(new InvokeCommand({
       FunctionName,
-      InvocationType,
-      Payload,
+      InvocationType: 'RequestResponse',
+      Payload: JSON.stringify(event),
     }));
   }
 


### PR DESCRIPTION
Our current offline SQS event payload contains only the message body. This is insufficient in applications where we need to inspect the metadata of received messages, and leads to `TypeError` in the consumer during testing.

This PR adds the missing fields to the event, trying to be relatively accurate. For example, the source queue ARN includes the correct queue name and AWS account ID. In terms of overall structure, an `SQSEvent` type is helpfully provided in the `@types/aws-lambda` package, which I've used to ensure our mocked event meets expectations.

Complete event samples can be found here for reference: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

Jira: [ENG-3437]

[ENG-3437]: https://comicrelief.atlassian.net/browse/ENG-3437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ