### PR TITLE
refactor: Alias the `alai` function

### DIFF
--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -14,7 +14,7 @@ import {
   SendMessageCommandInput,
 } from '@aws-sdk/client-sqs';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import alai from 'alai';
+import { default as getAccountIDFromARN } from 'alai';
 import { SQSEvent } from 'aws-lambda';
 import { v4 as uuid } from 'uuid';
 
@@ -246,7 +246,7 @@ export default class SQSService<
       REGION,
     } = process.env;
 
-    this.accountId = (di.context.invokedFunctionArn && alai.parse(di.context))
+    this.accountId = (di.context.invokedFunctionArn && getAccountIDFromARN.parse(di.context))
       || AWS_ACCOUNT_ID;
 
     if (di.isOffline && !Object.values(SQS_OFFLINE_MODES).includes(offlineMode)) {

--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -14,7 +14,7 @@ import {
   SendMessageCommandInput,
 } from '@aws-sdk/client-sqs';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import { default as getAccountIDFromARN } from 'alai';
+import getAccountIDFromARN from 'alai';
 import { SQSEvent } from 'aws-lambda';
 import { v4 as uuid } from 'uuid';
 

--- a/src/services/SQSService.ts
+++ b/src/services/SQSService.ts
@@ -14,7 +14,7 @@ import {
   SendMessageCommandInput,
 } from '@aws-sdk/client-sqs';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import getAccountIDFromARN from 'alai';
+import getAccountIDFromContext from 'alai';
 import { SQSEvent } from 'aws-lambda';
 import { v4 as uuid } from 'uuid';
 
@@ -246,7 +246,7 @@ export default class SQSService<
       REGION,
     } = process.env;
 
-    this.accountId = (di.context.invokedFunctionArn && getAccountIDFromARN.parse(di.context))
+    this.accountId = (di.context.invokedFunctionArn && getAccountIDFromContext.parse(di.context))
       || AWS_ACCOUNT_ID;
 
     if (di.isOffline && !Object.values(SQS_OFFLINE_MODES).includes(offlineMode)) {


### PR DESCRIPTION
The `alai` function works using the Lambda context object to parse the invoked function name. As an acronym for AWS Lambda Account ID it is not particularly memorable or descriptive. This PR aliases the function as `getAccountIDFromContext` to make it a little more understandable.

Tests pass.