### PR TITLE
ci: Pin Node version in `publish` job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
       - name: Restore cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Should fix this failed run: https://github.com/comicrelief/lambda-wrapper/actions/runs/13030440453

Not clear why this job wasn't already using `actions/setup-node`, but seems that Node 20 is now the default.

Setting to Node 18 for consistency with other jobs, for now, so we can unblock that publish. We do need to migrate everything to Node 20+, but as the last publish failure demonstrated, there's an incompatibility with one of the ESLint plugins. We need to resolve this in our ESLint config before we can upgrade here.