### PR TITLE
ci: Add semantic PR check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: PR checks
+
+on: pull_request
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pr:
+    # See https://github.com/amannn/action-semantic-pull-request
+    name: Semantic pull request
+    runs-on: ubuntu-latest
+    steps:
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a new GitHub Actions workflow that enforces a conventional commit-style title for all PRs.

We have this in most of our other repos now, but surprisingly not in this one!

Documentation for the action can be found here: https://github.com/amannn/action-semantic-pull-request