### PR TITLE
docs: Include wrap options in v2 migration guide

### DIFF
--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -77,6 +77,8 @@ Rather than passing in a config object everywhere you use Lambda Wrapper, you no
 
 v2 also drops support for callback-style async. Use promises instead.
 
+Wrap options (the `throwError` parameter) are now passed in as an object.
+
 Finally, there is no longer a `request` parameter provided to your wrapped function. You can get this from `di` if you need it.
 
 Instead of this:
@@ -101,6 +103,18 @@ export default lambdaWrapper.wrap(async (di) => {
   const request = di.get(RequestService);
   // ...
   return response;
+});
+```
+
+If using the `throwError` parameter, this needs to be replaced with the new `handleUncaughtErrors` wrap option. Note that the value should be negated; the new option's name better explains what Lambda Wrapper is doing, and needs the opposite value to select the same behaviour.
+
+```ts
+// v1
+export default lambdaWrapper.wrap(CONFIGURATION, handler, /* throwError */ true);
+
+// v2 equivalent
+export default lambdaWrapper.wrap(CONFIGURATION, handler, {
+  handleUncaughtErrors: false,
 });
 ```
 

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -110,10 +110,10 @@ If using the `throwError` parameter, this needs to be replaced with the new `han
 
 ```ts
 // v1
-export default lambdaWrapper.wrap(CONFIGURATION, handler, /* throwError */ true);
+export default LambdaWrapper(CONFIGURATION, handler, /* throwError */ true);
 
 // v2 equivalent
-export default lambdaWrapper.wrap(CONFIGURATION, handler, {
+export default lambdaWrapper.wrap(handler, {
   handleUncaughtErrors: false,
 });
 ```


### PR DESCRIPTION
A late addition to the migration guide. We provide an option to choose how the wrapper handles errors, which underwent a breaking change during the v2 TypeScript rewrite (#882), however this change was not documented anywhere.